### PR TITLE
Quadtree and Quadtree Viewer implementation

### DIFF
--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=1076,701
+Size=1014,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=1078,19
-Size=642,701
+Pos=1016,19
+Size=704,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1076,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1014,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=642,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=704,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -4,14 +4,14 @@ Size=500,500
 Collapsed=0
 
 [Window][Console]
-Pos=688,19
-Size=450,617
+Pos=1451,19
+Size=269,701
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Editor settings]
 Pos=0,19
-Size=364,617
+Size=364,701
 Collapsed=0
 DockId=0x00000003,0
 
@@ -27,19 +27,27 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=1138,617
+Size=1720,701
 Collapsed=0
 
 [Window][Sence]
-Pos=366,19
-Size=320,617
+Pos=0,19
+Size=1120,701
 Collapsed=0
 DockId=0x00000004,0
 
+[Window][Quadtree]
+Pos=1122,19
+Size=598,701
+Collapsed=0
+DockId=0x00000006,0
+
 [Docking][Data]
-DockSpace     ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1138,617 Split=X
-  DockNode    ID=0x00000001 Parent=0x7C6B3D9B SizeRef=686,736 Split=X
-    DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
-    DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
-  DockNode    ID=0x00000002 Parent=0x7C6B3D9B SizeRef=450,736 Selected=0x49278EEE
+DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1120,701 Split=X
+    DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
+      DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
+      DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
+    DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=598,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -27,27 +27,27 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=1720,701
+Size=960,521
 Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=917,701
+Size=478,521
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=919,19
-Size=801,701
+Pos=480,19
+Size=480,521
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
-DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=917,701 Split=X
+DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=960,521 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=478,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=801,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=480,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=987,701
+Size=923,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=989,19
-Size=731,701
+Pos=925,19
+Size=795,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=987,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=728,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=731,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=795,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=1014,701
+Size=986,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=1016,19
-Size=704,701
+Pos=988,19
+Size=732,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1014,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=986,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=704,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=732,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=930,701
+Size=987,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=932,19
-Size=788,701
+Pos=989,19
+Size=731,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=930,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=987,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=788,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=731,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -27,27 +27,27 @@ Collapsed=0
 
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=960,521
+Size=1720,701
 Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=478,521
+Size=930,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=480,19
-Size=480,521
+Pos=932,19
+Size=788,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
-DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=960,521 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=478,701 Split=X
+DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=930,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=480,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=788,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=1120,701
+Size=917,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=1122,19
-Size=598,701
+Pos=919,19
+Size=801,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1120,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=917,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=598,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=801,701 Selected=0x9E5071A3
 

--- a/Game/imgui.ini
+++ b/Game/imgui.ini
@@ -32,22 +32,22 @@ Collapsed=0
 
 [Window][Sence]
 Pos=0,19
-Size=923,701
+Size=1076,701
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Quadtree]
-Pos=925,19
-Size=795,701
+Pos=1078,19
+Size=642,701
 Collapsed=0
 DockId=0x00000006,0
 
 [Docking][Data]
 DockSpace       ID=0x7C6B3D9B Window=0xA87D555D Pos=0,19 Size=1720,701 Split=X
-  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=728,701 Split=X
+  DockNode      ID=0x00000005 Parent=0x7C6B3D9B SizeRef=1076,701 Split=X
     DockNode    ID=0x00000001 Parent=0x00000005 SizeRef=1449,736 Split=X
       DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=364,736 Selected=0xC5B20E51
       DockNode  ID=0x00000004 Parent=0x00000001 SizeRef=320,736 CentralNode=1 Selected=0x9964ADF7
     DockNode    ID=0x00000002 Parent=0x00000005 SizeRef=269,736 Selected=0x49278EEE
-  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=795,701 Selected=0x9E5071A3
+  DockNode      ID=0x00000006 Parent=0x7C6B3D9B SizeRef=642,701 Selected=0x9E5071A3
 

--- a/SobrassadaEngine/.clang-format
+++ b/SobrassadaEngine/.clang-format
@@ -28,3 +28,4 @@ IndentWidth: 4
 Language: Cpp
 BreakBeforeBraces: Allman
 SpaceBeforeCtorInitializerColon: true
+AllowShortFunctionsOnASingleLine: InlineOnly

--- a/SobrassadaEngine/Application.h
+++ b/SobrassadaEngine/Application.h
@@ -35,7 +35,7 @@ class Application
 
     // TMP: TEMPORAL JUST FOR HAVING A CAMERA TO RENDER
     CameraModule *GetCameraModule() { return cameraModule; }
-    DebugDrawModule *GetDebugDreawModule() { return debugDraw; }
+    DebugDrawModule *GetDebugDrawModule() { return debugDraw; }
     RenderTestModule *GetRenderTestModule() { return renderTest; }
     TextureModuleTest *GetTextureModuleTest() { return textureModuleTest; }
 

--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -5,6 +5,7 @@
 #include "MathGeoLib.h"
 #include "SDL_video.h"
 #include "WindowModule.h"
+#include "QaudtreeViewer.h"
 
 #define DEBUG_DRAW_IMPLEMENTATION
 #include "DebugDraw.h" // Debug Draw API. Notice that we need the DEBUG_DRAW_IMPLEMENTATION macro here!
@@ -624,4 +625,14 @@ void DebugDrawModule::Draw(const float4x4 &view, const float4x4 &proj, unsigned 
     implementation->mvpMatrix = proj * view;
 
     dd::flush();
+}
+
+void DebugDrawModule::RenderLines(float4x4& viewMatrix, float4x4& projectionMatrix, int width, int height)
+{
+    for (int i = 0; i < 10; ++i)
+    {
+        dd::line(ddVec3(0.f, 0.f, 0.f), ddVec3(10, 10 - i, 0.f), ddVec3(1.f, 0.f, 0.f));
+    }
+
+    Draw(viewMatrix, projectionMatrix, width, height);
 }

--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -632,8 +632,8 @@ void DebugDrawModule::Draw(const float4x4 &view, const float4x4 &proj, unsigned 
 }
 
 void DebugDrawModule::RenderQuadtreeViewportLines(
-    const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height, const std::list<float4> &lines,
-    const std::list<float4> &elementLines, const std::list<float4> &queryArea
+    const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height,
+    const std::vector<float4> &lines, const std::vector<float4> &elementLines, const std::vector<float4> &queryArea
 )
 {
 

--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -3,9 +3,9 @@
 #include "CameraModule.h"
 #include "Globals.h"
 #include "MathGeoLib.h"
+#include "QaudtreeViewer.h"
 #include "SDL_video.h"
 #include "WindowModule.h"
-#include "QaudtreeViewer.h"
 
 #define DEBUG_DRAW_IMPLEMENTATION
 #include "DebugDraw.h" // Debug Draw API. Notice that we need the DEBUG_DRAW_IMPLEMENTATION macro here!
@@ -579,9 +579,13 @@ const char *DDRenderInterfaceCoreGL::textFragShaderSrc =
 
 DDRenderInterfaceCoreGL *DebugDrawModule::implementation = 0;
 
-DebugDrawModule::DebugDrawModule() {}
+DebugDrawModule::DebugDrawModule()
+{
+}
 
-DebugDrawModule::~DebugDrawModule() {}
+DebugDrawModule::~DebugDrawModule()
+{
+}
 
 bool DebugDrawModule::Init()
 {
@@ -627,11 +631,20 @@ void DebugDrawModule::Draw(const float4x4 &view, const float4x4 &proj, unsigned 
     dd::flush();
 }
 
-void DebugDrawModule::RenderLines(float4x4& viewMatrix, float4x4& projectionMatrix, int width, int height)
+void DebugDrawModule::RenderLines(
+    float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height, std::list<float4> &lines,
+    std::list<float4> &elementLines
+)
 {
-    for (int i = 0; i < 10; ++i)
+
+    for (auto &line : lines)
     {
-        dd::line(ddVec3(0.f, 0.f, 0.f), ddVec3(10, 10 - i, 0.f), ddVec3(1.f, 0.f, 0.f));
+        dd::line(ddVec3(line.x, line.y, 0.f), ddVec3(line.z, line.w, 0.f), ddVec3(1.f, 0.f, 0.f));
+    }
+
+    for (auto &line : elementLines)
+    {
+        dd::line(ddVec3(line.x, line.y, 1.f), ddVec3(line.z, line.w, 1.f), ddVec3(0.f, 0.f, 1.f));
     }
 
     Draw(viewMatrix, projectionMatrix, width, height);

--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -631,9 +631,9 @@ void DebugDrawModule::Draw(const float4x4 &view, const float4x4 &proj, unsigned 
     dd::flush();
 }
 
-void DebugDrawModule::RenderLines(
-    float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height, std::list<float4> &lines,
-    std::list<float4> &elementLines
+void DebugDrawModule::RenderQuadtreeViewportLines(
+    const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height, const std::list<float4> &lines,
+    const std::list<float4> &elementLines, const std::list<float4> &queryArea
 )
 {
 
@@ -645,6 +645,11 @@ void DebugDrawModule::RenderLines(
     for (auto &line : elementLines)
     {
         dd::line(ddVec3(line.x, line.y, 1.f), ddVec3(line.z, line.w, 1.f), ddVec3(0.f, 0.f, 1.f));
+    }
+
+    for (auto &line : queryArea)
+    {
+        dd::line(ddVec3(line.x, line.y, 1.f), ddVec3(line.z, line.w, 1.f), ddVec3(0.f, 1.f, 0.f));
     }
 
     Draw(viewMatrix, projectionMatrix, width, height);

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -18,6 +18,7 @@ class DebugDrawModule : public Module
     bool ShutDown() override;
 
     void Draw(const float4x4 &view, const float4x4 &proj, unsigned width, unsigned height);
+    void RenderLines(float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height);
 
   private:
     static DDRenderInterfaceCoreGL *implementation;

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -20,8 +20,8 @@ class DebugDrawModule : public Module
 
     void Draw(const float4x4 &view, const float4x4 &proj, unsigned width, unsigned height);
     void RenderQuadtreeViewportLines(
-        const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height, const std::list<float4> &lines,
-        const std::list<float4> &elementLines, const std::list<float4> &queryArea
+        const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height,
+        const std::vector<float4> &lines, const std::vector<float4> &elementLines, const std::vector<float4> &queryArea
     );
 
   private:

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -19,9 +19,9 @@ class DebugDrawModule : public Module
     bool ShutDown() override;
 
     void Draw(const float4x4 &view, const float4x4 &proj, unsigned width, unsigned height);
-    void RenderLines(
-        float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height, std::list<float4> &lines,
-        std::list<float4> &elementLines
+    void RenderQuadtreeViewportLines(
+        const float4x4 &viewMatrix, const float4x4 &projectionMatrix, int width, int height, const std::list<float4> &lines,
+        const std::list<float4> &elementLines, const std::list<float4> &queryArea
     );
 
   private:

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -3,6 +3,7 @@
 #include "Module.h"
 
 #include "Math/float4x4.h"
+#include <list>
 
 class DDRenderInterfaceCoreGL;
 class Camera;
@@ -18,7 +19,10 @@ class DebugDrawModule : public Module
     bool ShutDown() override;
 
     void Draw(const float4x4 &view, const float4x4 &proj, unsigned width, unsigned height);
-    void RenderLines(float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height);
+    void RenderLines(
+        float4x4 &viewMatrix, float4x4 &projectionMatrix, int width, int height, std::list<float4> &lines,
+        std::list<float4> &elementLines
+    );
 
   private:
     static DDRenderInterfaceCoreGL *implementation;

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj
@@ -133,6 +133,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
+    <ClCompile Include="Utils\Quadtree.cpp" />
     <ClCompile Include="UI\QaudtreeViewer.cpp" />
     <ClCompile Include="Scene\Components\Component.cpp" />
     <ClCompile Include="Utils\Framebuffer.cpp" />
@@ -193,6 +194,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h" />
+    <ClInclude Include="Utils\Quadtree.h" />
     <ClInclude Include="UI\QaudtreeViewer.h" />
     <ClInclude Include="Scene\Components\Component.h" />
     <ClInclude Include="Utils\Framebuffer.h" />

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj
@@ -134,7 +134,7 @@
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
     <ClCompile Include="Utils\Quadtree.cpp" />
-    <ClCompile Include="UI\QaudtreeViewer.cpp" />
+    <ClCompile Include="UI\QuadtreeViewer.cpp" />
     <ClCompile Include="Scene\Components\Component.cpp" />
     <ClCompile Include="Utils\Framebuffer.cpp" />
     <ClCompile Include="UI\EditorViewport.cpp" />
@@ -195,7 +195,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="Utils\Quadtree.h" />
-    <ClInclude Include="UI\QaudtreeViewer.h" />
+    <ClInclude Include="UI\QuadtreeViewer.h" />
     <ClInclude Include="Scene\Components\Component.h" />
     <ClInclude Include="Utils\Framebuffer.h" />
     <ClInclude Include="UI\EditorViewport.h" />

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj
@@ -133,6 +133,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
+    <ClCompile Include="UI\QaudtreeViewer.cpp" />
     <ClCompile Include="Scene\Components\Component.cpp" />
     <ClCompile Include="Utils\Framebuffer.cpp" />
     <ClCompile Include="UI\EditorViewport.cpp" />
@@ -192,6 +193,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h" />
+    <ClInclude Include="UI\QaudtreeViewer.h" />
     <ClInclude Include="Scene\Components\Component.h" />
     <ClInclude Include="Utils\Framebuffer.h" />
     <ClInclude Include="UI\EditorViewport.h" />

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
@@ -165,6 +165,10 @@
     <ClCompile Include="UI\EditorViewport.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="Scene\Components\Component.cpp" />
+    <ClCompile Include="UI\QaudtreeViewer.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Modules">
@@ -270,6 +274,10 @@
       <Filter>Utils</Filter>
     </ClInclude>
     <ClInclude Include="UI\EditorViewport.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="Scene\Components\Component.h" />
+    <ClInclude Include="UI\QaudtreeViewer.h">
       <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
@@ -166,7 +166,7 @@
       <Filter>UI</Filter>
     </ClCompile>
     <ClCompile Include="Scene\Components\Component.cpp" />
-    <ClCompile Include="UI\QaudtreeViewer.cpp">
+    <ClCompile Include="UI\QuadtreeViewer.cpp">
       <Filter>UI</Filter>
     </ClCompile>
     <ClCompile Include="Utils\Quadtree.cpp">
@@ -280,7 +280,7 @@
       <Filter>UI</Filter>
     </ClInclude>
     <ClInclude Include="Scene\Components\Component.h" />
-    <ClInclude Include="UI\QaudtreeViewer.h">
+    <ClInclude Include="UI\QuadtreeViewer.h">
       <Filter>UI</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Quadtree.h">

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClCompile Include="UI\QaudtreeViewer.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="Utils\Quadtree.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Modules">
@@ -279,6 +282,9 @@
     <ClInclude Include="Scene\Components\Component.h" />
     <ClInclude Include="UI\QaudtreeViewer.h">
       <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\Quadtree.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/SobrassadaEngine/Tests/EngineMesh.cpp
+++ b/SobrassadaEngine/Tests/EngineMesh.cpp
@@ -193,4 +193,6 @@ void EngineMesh::Render(int program, int texturePosition, float4x4& projectionMa
 
 		glDrawArrays(GL_TRIANGLES, 0, vertexCount);
 	}
+
+	glBindVertexArray(0);
 }

--- a/SobrassadaEngine/UI/EditorUIModule.cpp
+++ b/SobrassadaEngine/UI/EditorUIModule.cpp
@@ -4,6 +4,7 @@
 #include "EditorViewport.h"
 #include "OpenGLModule.h"
 #include "WindowModule.h"
+#include "QaudtreeViewer.h"
 
 #include "glew.h"
 #include "imgui.h"
@@ -26,6 +27,7 @@ bool EditorUIModule::Init()
     ImGui_ImplOpenGL3_Init("#version 460");
 
     editorViewport = new EditorViewport();
+    quadtreeViewer = new QaudtreeViewer();
 
     return true;
 }
@@ -51,6 +53,8 @@ update_status EditorUIModule::RenderEditor(float deltaTime)
 
     editorViewport->Render();
 
+    if (quadtreeViewerViewport) quadtreeViewer->Render(quadtreeViewerViewport);
+
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
@@ -74,6 +78,7 @@ bool EditorUIModule::ShutDown()
     frametime.clear();
 
     delete editorViewport;
+    delete quadtreeViewer;
 
     return true;
 }
@@ -118,6 +123,8 @@ void EditorUIModule::MainMenu()
     if (ImGui::BeginMenu("General"))
     {
         if (ImGui::MenuItem("Console")) consoleMenu = !consoleMenu;
+        
+        if (ImGui::MenuItem("Quadtree")) quadtreeViewerViewport = !quadtreeViewerViewport;
 
         if (ImGui::MenuItem("Quit")) closeApplication = true;
 

--- a/SobrassadaEngine/UI/EditorUIModule.cpp
+++ b/SobrassadaEngine/UI/EditorUIModule.cpp
@@ -4,7 +4,7 @@
 #include "EditorViewport.h"
 #include "OpenGLModule.h"
 #include "WindowModule.h"
-#include "QaudtreeViewer.h"
+#include "QuadtreeViewer.h"
 
 #include "glew.h"
 #include "imgui.h"
@@ -27,7 +27,7 @@ bool EditorUIModule::Init()
     ImGui_ImplOpenGL3_Init("#version 460");
 
     editorViewport = new EditorViewport();
-    quadtreeViewer = new QaudtreeViewer();
+    quadtreeViewer = new QuadtreeViewer();
 
     return true;
 }

--- a/SobrassadaEngine/UI/EditorUIModule.h
+++ b/SobrassadaEngine/UI/EditorUIModule.h
@@ -5,7 +5,7 @@
 #include <deque>
 
 class EditorViewport;
-class QaudtreeViewer;
+class QuadtreeViewer;
 
 class EditorUIModule : public Module
 {
@@ -45,5 +45,5 @@ class EditorUIModule : public Module
     std::deque<float> frametime;
 
     EditorViewport *editorViewport = nullptr;
-    QaudtreeViewer *quadtreeViewer = nullptr;
+    QuadtreeViewer *quadtreeViewer = nullptr;
 };

--- a/SobrassadaEngine/UI/EditorUIModule.h
+++ b/SobrassadaEngine/UI/EditorUIModule.h
@@ -5,6 +5,7 @@
 #include <deque>
 
 class EditorViewport;
+class QaudtreeViewer;
 
 class EditorUIModule : public Module
 {
@@ -34,13 +35,15 @@ class EditorUIModule : public Module
     void Console(bool &consoleMenu);
 
   private:
-    bool consoleMenu        = false;
-    bool editorSettingsMenu = false;
-    bool closeApplication   = false;
+    bool consoleMenu            = false;
+    bool editorSettingsMenu     = false;
+    bool quadtreeViewerViewport = false;
+    bool closeApplication       = false;
 
-    int maximumPlotData     = 50;
+    int maximumPlotData         = 50;
     std::deque<float> framerate;
     std::deque<float> frametime;
 
     EditorViewport *editorViewport = nullptr;
+    QaudtreeViewer *quadtreeViewer = nullptr;
 };

--- a/SobrassadaEngine/UI/EditorUIModule.h
+++ b/SobrassadaEngine/UI/EditorUIModule.h
@@ -37,7 +37,7 @@ class EditorUIModule : public Module
   private:
     bool consoleMenu            = false;
     bool editorSettingsMenu     = false;
-    bool quadtreeViewerViewport = false;
+    bool quadtreeViewerViewport = true;
     bool closeApplication       = false;
 
     int maximumPlotData         = 50;

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -14,7 +14,7 @@
 QaudtreeViewer::QaudtreeViewer()
 {
     framebuffer               = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
-    quadtree                  = new Quadtree(float2(-10, 10), 20, 2);
+    quadtree                  = new Quadtree(float2(0, 0), 20, 2);
 
     // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
     camera.type               = FrustumType::OrthographicFrustum;
@@ -32,13 +32,13 @@ QaudtreeViewer::QaudtreeViewer()
 
     // TODO: REMOVE, JUST FOR TESTING QUADTREE GENERATION
     math::LCG randomGenerator;
-    int samplePoints = 10;
+    int samplePoints = 3;
 
     for (int i = 0; i < samplePoints; ++i)
     {
-        int xCoord      = randomGenerator.Int(-10, 10);
-        int yCoord      = randomGenerator.Int(-10, 10);
-        float4 newPoint = float4((float)xCoord, (float)yCoord, 2.f, 2.f);
+        float xCoord    = randomGenerator.Float(-10, 10);
+        float yCoord    = randomGenerator.Float(-10, 10);
+        float4 newPoint = float4(xCoord, yCoord, 1.f, 1.f);
 
         quadtree->InsertElement(newPoint);
     }

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -1,11 +1,8 @@
 #include "QaudtreeViewer.h"
 
 #include "Application.h"
-#include "CameraModule.h"
 #include "Framebuffer.h"
 #include "Globals.h"
-#include "ShaderModule.h"
-#include "WindowModule.h"
 #include "DebugDrawModule.h"
 
 #include "SDL.h"
@@ -14,20 +11,7 @@
 
 QaudtreeViewer::QaudtreeViewer()
 {
-    program     = App->GetShaderModule()->GetProgram("./Test/basicVertexShader.vs", "./Test/basicFragmentShader.fs");
     framebuffer = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
-    // Triangle
-    /*float vtx_data[] = {
-        -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
-    };*/
-
-    // Lines
-    float vtx_data[] = {-1.0f, -1.0f, 0.f, 1.0f, -1.0f, 0.f};
-
-    glGenBuffers(1, &vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vtx_data), vtx_data, GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
     camera.type               = FrustumType::OrthographicFrustum;
@@ -47,7 +31,6 @@ QaudtreeViewer::QaudtreeViewer()
 QaudtreeViewer::~QaudtreeViewer()
 {
     delete framebuffer;
-    glDeleteBuffers(1, &vbo);
 }
 
 void QaudtreeViewer::Render(bool &renderBoolean)
@@ -59,27 +42,6 @@ void QaudtreeViewer::Render(bool &renderBoolean)
     glViewport(0, 0, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight());
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    //float4x4 model;
-    //model = float4x4::identity;
-
-    //glUseProgram(program);
-    //glUniformMatrix4fv(0, 1, GL_TRUE, &projectionMatrix[0][0]);
-    //glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
-    //glUniformMatrix4fv(2, 1, GL_TRUE, &model[0][0]);
-
-    //glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    //glEnableVertexAttribArray(0);
-    //glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
-
-    //// Triangle
-    //// glDrawArrays(GL_TRIANGLES, 0, 3);
-    //glDrawArrays(GL_LINES, 0, 2);
-
-    //// Unbind everything to not mess with other renders
-    //glBindBuffer(GL_ARRAY_BUFFER, 0);
-    //glBindTexture(GL_TEXTURE_2D, 0);
-    //glActiveTexture(0);
 
     App->GetDebugDreawModule()->RenderLines(viewMatrix, projectionMatrix, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight());
 

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -1,11 +1,11 @@
 #include "QaudtreeViewer.h"
 
 #include "Application.h"
+#include "CameraModule.h"
 #include "Framebuffer.h"
 #include "Globals.h"
-#include "WindowModule.h"
 #include "ShaderModule.h"
-#include "CameraModule.h"
+#include "WindowModule.h"
 
 #include "SDL.h"
 #include "glew.h"
@@ -13,17 +13,34 @@
 
 QaudtreeViewer::QaudtreeViewer()
 {
-    // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
     program     = App->GetShaderModule()->GetProgram("./Test/basicVertexShader.vs", "./Test/basicFragmentShader.fs");
     framebuffer = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
-    float vtx_data[] = {
+    // Triangle
+    /*float vtx_data[] = {
         -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
-    };
+    };*/
+
+    // Lines
+    float vtx_data[] = {-1.0f, -1.0f, 1.0f, -1.0f};
 
     glGenBuffers(1, &vbo);
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     glBufferData(GL_ARRAY_BUFFER, sizeof(vtx_data), vtx_data, GL_STATIC_DRAW);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
+    camera.type               = FrustumType::OrthographicFrustum;
+    camera.pos                = float3(0, 0, 5);
+    camera.front              = -float3::unitZ;
+    camera.up                 = float3::unitY;
+    camera.nearPlaneDistance  = 0.1f;
+    camera.farPlaneDistance   = 100.f;
+
+    camera.orthographicHeight = (float)framebuffer->GetTextureHeight() / cameraSizeScaleFactor;
+    camera.orthographicWidth  = (float)framebuffer->GetTextureWidth() / cameraSizeScaleFactor;
+
+    viewMatrix                = camera.ViewMatrix();
+    projectionMatrix          = camera.ProjectionMatrix();
 }
 
 QaudtreeViewer::~QaudtreeViewer()
@@ -39,24 +56,29 @@ void QaudtreeViewer::Render(bool &renderBoolean)
 
     // Clear current viewport
     glViewport(0, 0, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight());
-    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    float4x4 model, view, proj;
-    proj  = App->GetCameraModule()->GetProjectionMatrix();
-    view  = App->GetCameraModule()->GetViewMatrix();
+    float4x4 model;
     model = float4x4::identity;
 
     glUseProgram(program);
-    glUniformMatrix4fv(0, 1, GL_TRUE, &proj[0][0]);
-    glUniformMatrix4fv(1, 1, GL_TRUE, &view[0][0]);
+    glUniformMatrix4fv(0, 1, GL_TRUE, &projectionMatrix[0][0]);
+    glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
     glUniformMatrix4fv(2, 1, GL_TRUE, &model[0][0]);
 
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
 
-    glDrawArrays(GL_TRIANGLES, 0, 3);
+    // Triangle
+    // glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
+
+    // Lines
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, (void *)0);
+
+    // Triangle
+    // glDrawArrays(GL_TRIANGLES, 0, 3);
+    glDrawArrays(GL_LINES, 0, 2);
 
     // Unbind everything to not mess with other renders
     glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -85,10 +107,19 @@ void QaudtreeViewer::Render(bool &renderBoolean)
             ImVec2 windowSize = ImGui::GetWindowSize();
             if (framebuffer->GetTextureWidth() != windowSize.x || framebuffer->GetTextureHeight() != windowSize.y)
             {
-                float aspectRatio = windowSize.y / windowSize.x;
+                ChangeCameraSize(windowSize.x, windowSize.y);
                 framebuffer->Resize((int)windowSize.x, (int)windowSize.y);
             }
         }
     }
     ImGui::End();
+}
+
+void QaudtreeViewer::ChangeCameraSize(float width, float height) 
+{
+    camera.orthographicHeight = width / cameraSizeScaleFactor;
+    camera.orthographicWidth  = height / cameraSizeScaleFactor;
+
+    viewMatrix                = camera.ViewMatrix();
+    projectionMatrix          = camera.ProjectionMatrix();
 }

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -1,0 +1,94 @@
+#include "QaudtreeViewer.h"
+
+#include "Application.h"
+#include "Framebuffer.h"
+#include "Globals.h"
+#include "WindowModule.h"
+#include "ShaderModule.h"
+#include "CameraModule.h"
+
+#include "SDL.h"
+#include "glew.h"
+#include "imgui.h"
+
+QaudtreeViewer::QaudtreeViewer()
+{
+    // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
+    program     = App->GetShaderModule()->GetProgram("./Test/basicVertexShader.vs", "./Test/basicFragmentShader.fs");
+    framebuffer = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
+    float vtx_data[] = {
+        -1.0f, -1.0f, 0.0f, 1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+    };
+
+    glGenBuffers(1, &vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vtx_data), vtx_data, GL_STATIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+QaudtreeViewer::~QaudtreeViewer()
+{
+    delete framebuffer;
+    glDeleteBuffers(1, &vbo);
+}
+
+void QaudtreeViewer::Render(bool &renderBoolean)
+{
+    framebuffer->CheckResize();
+    framebuffer->Bind();
+
+    // Clear current viewport
+    glViewport(0, 0, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight());
+    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    float4x4 model, view, proj;
+    proj  = App->GetCameraModule()->GetProjectionMatrix();
+    view  = App->GetCameraModule()->GetViewMatrix();
+    model = float4x4::identity;
+
+    glUseProgram(program);
+    glUniformMatrix4fv(0, 1, GL_TRUE, &proj[0][0]);
+    glUniformMatrix4fv(1, 1, GL_TRUE, &view[0][0]);
+    glUniformMatrix4fv(2, 1, GL_TRUE, &model[0][0]);
+
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
+
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    // Unbind everything to not mess with other renders
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(0);
+
+    framebuffer->Unbind();
+
+    if (ImGui::Begin("Quadtree", &renderBoolean))
+    {
+        if (ImGui::BeginChild(
+                "##SceneChild", ImVec2(0.f, 0.f), NULL,
+                ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar
+            ))
+        {
+            ImGui::SetCursorPos(ImVec2(0.f, 0.f));
+
+            ImGui::Image(
+                (ImTextureID)framebuffer->GetTextureID(),
+                ImVec2((float)framebuffer->GetTextureWidth(), (float)framebuffer->GetTextureHeight()), ImVec2(0.f, 1.f),
+                ImVec2(1.f, 0.f)
+            );
+
+            ImGui::EndChild();
+
+            ImVec2 windowSize = ImGui::GetWindowSize();
+            if (framebuffer->GetTextureWidth() != windowSize.x || framebuffer->GetTextureHeight() != windowSize.y)
+            {
+                float aspectRatio = windowSize.y / windowSize.x;
+                framebuffer->Resize((int)windowSize.x, (int)windowSize.y);
+            }
+        }
+    }
+    ImGui::End();
+}

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -6,6 +6,7 @@
 #include "Globals.h"
 #include "ShaderModule.h"
 #include "WindowModule.h"
+#include "DebugDrawModule.h"
 
 #include "SDL.h"
 #include "glew.h"
@@ -59,26 +60,28 @@ void QaudtreeViewer::Render(bool &renderBoolean)
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    float4x4 model;
-    model = float4x4::identity;
+    //float4x4 model;
+    //model = float4x4::identity;
 
-    glUseProgram(program);
-    glUniformMatrix4fv(0, 1, GL_TRUE, &projectionMatrix[0][0]);
-    glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
-    glUniformMatrix4fv(2, 1, GL_TRUE, &model[0][0]);
+    //glUseProgram(program);
+    //glUniformMatrix4fv(0, 1, GL_TRUE, &projectionMatrix[0][0]);
+    //glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
+    //glUniformMatrix4fv(2, 1, GL_TRUE, &model[0][0]);
 
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
+    //glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    //glEnableVertexAttribArray(0);
+    //glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
 
-    // Triangle
-    // glDrawArrays(GL_TRIANGLES, 0, 3);
-    glDrawArrays(GL_LINES, 0, 2);
+    //// Triangle
+    //// glDrawArrays(GL_TRIANGLES, 0, 3);
+    //glDrawArrays(GL_LINES, 0, 2);
 
-    // Unbind everything to not mess with other renders
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindTexture(GL_TEXTURE_2D, 0);
-    glActiveTexture(0);
+    //// Unbind everything to not mess with other renders
+    //glBindBuffer(GL_ARRAY_BUFFER, 0);
+    //glBindTexture(GL_TEXTURE_2D, 0);
+    //glActiveTexture(0);
+
+    App->GetDebugDreawModule()->RenderLines(viewMatrix, projectionMatrix, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight());
 
     framebuffer->Unbind();
 

--- a/SobrassadaEngine/UI/QaudtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QaudtreeViewer.cpp
@@ -21,7 +21,7 @@ QaudtreeViewer::QaudtreeViewer()
     };*/
 
     // Lines
-    float vtx_data[] = {-1.0f, -1.0f, 1.0f, -1.0f};
+    float vtx_data[] = {-1.0f, -1.0f, 0.f, 1.0f, -1.0f, 0.f};
 
     glGenBuffers(1, &vbo);
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
@@ -69,12 +69,7 @@ void QaudtreeViewer::Render(bool &renderBoolean)
 
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
     glEnableVertexAttribArray(0);
-
-    // Triangle
-    // glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
-
-    // Lines
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, (void *)0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, (void *)0);
 
     // Triangle
     // glDrawArrays(GL_TRIANGLES, 0, 3);

--- a/SobrassadaEngine/UI/QaudtreeViewer.h
+++ b/SobrassadaEngine/UI/QaudtreeViewer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class Framebuffer;
+
+class QaudtreeViewer
+{
+  public:
+    QaudtreeViewer();
+    ~QaudtreeViewer();
+
+    void Render(bool& renderBoolean);
+
+  private:
+    Framebuffer *framebuffer;
+    unsigned int vbo = 0;
+    unsigned int program = 0;
+};

--- a/SobrassadaEngine/UI/QaudtreeViewer.h
+++ b/SobrassadaEngine/UI/QaudtreeViewer.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "Geometry/Frustum.h"
+#include "Math/float4x4.h"
+
 class Framebuffer;
 
 class QaudtreeViewer
@@ -8,10 +11,18 @@ class QaudtreeViewer
     QaudtreeViewer();
     ~QaudtreeViewer();
 
-    void Render(bool& renderBoolean);
+    void Render(bool &renderBoolean);
+
+  private:
+    void ChangeCameraSize(float width, float height);
 
   private:
     Framebuffer *framebuffer;
-    unsigned int vbo = 0;
-    unsigned int program = 0;
+    unsigned int vbo            = 0;
+    unsigned int program        = 0;
+    float cameraSizeScaleFactor = 10.f;
+
+    Frustum camera;
+    float4x4 viewMatrix;
+    float4x4 projectionMatrix;
 };

--- a/SobrassadaEngine/UI/QaudtreeViewer.h
+++ b/SobrassadaEngine/UI/QaudtreeViewer.h
@@ -4,6 +4,7 @@
 #include "Math/float4x4.h"
 
 class Framebuffer;
+class Quadtree;
 
 class QaudtreeViewer
 {
@@ -18,6 +19,7 @@ class QaudtreeViewer
 
   private:
     Framebuffer *framebuffer;
+    Quadtree *quadtree;
     float cameraSizeScaleFactor = 10.f;
 
     Frustum camera;

--- a/SobrassadaEngine/UI/QaudtreeViewer.h
+++ b/SobrassadaEngine/UI/QaudtreeViewer.h
@@ -2,9 +2,12 @@
 
 #include "Geometry/Frustum.h"
 #include "Math/float4x4.h"
+#include <list>
 
 class Framebuffer;
 class Quadtree;
+
+struct Box;
 
 class QaudtreeViewer
 {
@@ -16,6 +19,7 @@ class QaudtreeViewer
 
   private:
     void ChangeCameraSize(float width, float height);
+    void CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const;
 
   private:
     Framebuffer *framebuffer;

--- a/SobrassadaEngine/UI/QaudtreeViewer.h
+++ b/SobrassadaEngine/UI/QaudtreeViewer.h
@@ -18,8 +18,6 @@ class QaudtreeViewer
 
   private:
     Framebuffer *framebuffer;
-    unsigned int vbo            = 0;
-    unsigned int program        = 0;
     float cameraSizeScaleFactor = 10.f;
 
     Frustum camera;

--- a/SobrassadaEngine/UI/QuadtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QuadtreeViewer.cpp
@@ -1,4 +1,4 @@
-#include "QaudtreeViewer.h"
+#include "QuadtreeViewer.h"
 
 #include "Application.h"
 #include "DebugDrawModule.h"
@@ -11,24 +11,26 @@
 #include "glew.h"
 #include "imgui.h"
 
-QaudtreeViewer::QaudtreeViewer()
+QuadtreeViewer::QuadtreeViewer()
 {
-    framebuffer               = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
-    quadtree                  = new Quadtree(float2(0, 0), 20, 2);
+    framebuffer              = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
+    quadtree                 = new Quadtree(float2(0, 0), 20, 2);
 
     // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
-    camera.type               = FrustumType::OrthographicFrustum;
-    camera.pos                = float3(0, 0, 5);
-    camera.front              = -float3::unitZ;
-    camera.up                 = float3::unitY;
-    camera.nearPlaneDistance  = 0.1f;
-    camera.farPlaneDistance   = 100.f;
+    camera.type              = FrustumType::OrthographicFrustum;
+    camera.pos               = float3(0, 0, 5);
+    camera.front             = -float3::unitZ;
+    camera.up                = float3::unitY;
+    camera.nearPlaneDistance = 0.1f;
+    camera.farPlaneDistance  = 100.f;
 
-    camera.orthographicHeight = (float)framebuffer->GetTextureHeight() / cameraSizeScaleFactor;
-    camera.orthographicWidth  = (float)framebuffer->GetTextureWidth() / cameraSizeScaleFactor;
+    float aspectRatio        = (float)framebuffer->GetTextureHeight() / (float)framebuffer->GetTextureWidth();
 
-    viewMatrix                = camera.ViewMatrix();
-    projectionMatrix          = camera.ProjectionMatrix();
+    camera.orthographicWidth  = (float)framebuffer->GetTextureWidth() * aspectRatio / cameraSizeScaleFactor;
+    camera.orthographicHeight = (float)framebuffer->GetTextureHeight() * aspectRatio / cameraSizeScaleFactor;
+
+    viewMatrix               = camera.ViewMatrix();
+    projectionMatrix         = camera.ProjectionMatrix();
 
     // TODO: REMOVE, JUST FOR TESTING QUADTREE GENERATION
     math::LCG randomGenerator;
@@ -36,20 +38,20 @@ QaudtreeViewer::QaudtreeViewer()
 
     for (int i = 0; i < samplePoints; ++i)
     {
-        float xCoord    = randomGenerator.Float(-10, 10);
-        float yCoord    = randomGenerator.Float(-10, 10);
-        Box newPoint    = Box(xCoord, yCoord, 1.f, 1.f);
+        float xCoord = randomGenerator.Float(-10, 10);
+        float yCoord = randomGenerator.Float(-10, 10);
+        Box newPoint = Box(xCoord, yCoord, 1.f, 1.f);
 
         quadtree->InsertElement(newPoint);
     }
 }
 
-QaudtreeViewer::~QaudtreeViewer()
+QuadtreeViewer::~QuadtreeViewer()
 {
     delete framebuffer;
 }
 
-void QaudtreeViewer::Render(bool &renderBoolean)
+void QuadtreeViewer::Render(bool &renderBoolean)
 {
     framebuffer->CheckResize();
     framebuffer->Bind();
@@ -70,7 +72,7 @@ void QaudtreeViewer::Render(bool &renderBoolean)
 
     CreateQueryAreaLines(queryArea, queryAreaLines);
 
-    App->GetDebugDreawModule()->RenderQuadtreeViewportLines(
+    App->GetDebugDrawModule()->RenderQuadtreeViewportLines(
         viewMatrix, projectionMatrix, framebuffer->GetTextureWidth(), framebuffer->GetTextureHeight(), drawLines,
         elementLines, queryAreaLines
     );
@@ -105,16 +107,16 @@ void QaudtreeViewer::Render(bool &renderBoolean)
     ImGui::End();
 }
 
-void QaudtreeViewer::ChangeCameraSize(float width, float height)
+void QuadtreeViewer::ChangeCameraSize(float width, float height)
 {
-    camera.orthographicHeight = width / cameraSizeScaleFactor;
-    camera.orthographicWidth  = height / cameraSizeScaleFactor;
+    float aspectRatio         = height / width;
+    camera.orthographicHeight = height * aspectRatio / cameraSizeScaleFactor;
 
     viewMatrix                = camera.ViewMatrix();
     projectionMatrix          = camera.ProjectionMatrix();
 }
 
-void QaudtreeViewer::CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const
+void QuadtreeViewer::CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const
 {
     float halfSizeX    = queryArea.sizeX / 2.f;
     float halfSizeY    = queryArea.sizeY / 2.f;

--- a/SobrassadaEngine/UI/QuadtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QuadtreeViewer.cpp
@@ -13,24 +13,24 @@
 
 QuadtreeViewer::QuadtreeViewer()
 {
-    framebuffer              = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
-    quadtree                 = new Quadtree(float2(0, 0), 20, 2);
+    framebuffer               = new Framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT, true);
+    quadtree                  = new Quadtree(float2(0, 0), 20, 2);
 
     // TODO: USE CAMERA COMPONENT / CLASS TO CREATE A ORTHOGONAL CAMERA FRON RENDERING THE QUADTREE
-    camera.type              = FrustumType::OrthographicFrustum;
-    camera.pos               = float3(0, 0, 5);
-    camera.front             = -float3::unitZ;
-    camera.up                = float3::unitY;
-    camera.nearPlaneDistance = 0.1f;
-    camera.farPlaneDistance  = 100.f;
+    camera.type               = FrustumType::OrthographicFrustum;
+    camera.pos                = float3(0, 0, 5);
+    camera.front              = -float3::unitZ;
+    camera.up                 = float3::unitY;
+    camera.nearPlaneDistance  = 0.1f;
+    camera.farPlaneDistance   = 100.f;
 
-    float aspectRatio        = (float)framebuffer->GetTextureHeight() / (float)framebuffer->GetTextureWidth();
+    float aspectRatio         = (float)framebuffer->GetTextureHeight() / (float)framebuffer->GetTextureWidth();
 
     camera.orthographicWidth  = (float)framebuffer->GetTextureWidth() * aspectRatio / cameraSizeScaleFactor;
     camera.orthographicHeight = (float)framebuffer->GetTextureHeight() * aspectRatio / cameraSizeScaleFactor;
 
-    viewMatrix               = camera.ViewMatrix();
-    projectionMatrix         = camera.ProjectionMatrix();
+    viewMatrix                = camera.ViewMatrix();
+    projectionMatrix          = camera.ProjectionMatrix();
 
     // TODO: REMOVE, JUST FOR TESTING QUADTREE GENERATION
     math::LCG randomGenerator;
@@ -61,9 +61,9 @@ void QuadtreeViewer::Render(bool &renderBoolean)
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    std::list<float4> drawLines;
-    std::list<float4> elementLines;
-    std::list<float4> queryAreaLines;
+    std::vector<float4> drawLines;
+    std::vector<float4> elementLines;
+    std::vector<float4> queryAreaLines;
     quadtree->GetDrawLines(drawLines, elementLines);
 
     Box queryArea = Box(5, 5, 5, 5);
@@ -116,8 +116,10 @@ void QuadtreeViewer::ChangeCameraSize(float width, float height)
     projectionMatrix          = camera.ProjectionMatrix();
 }
 
-void QuadtreeViewer::CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const
+void QuadtreeViewer::CreateQueryAreaLines(const Box &queryArea, std::vector<float4> &queryAreaLines) const
 {
+    queryAreaLines     = std::vector<float4>(4);
+
     float halfSizeX    = queryArea.sizeX / 2.f;
     float halfSizeY    = queryArea.sizeY / 2.f;
 
@@ -126,8 +128,8 @@ void QuadtreeViewer::CreateQueryAreaLines(const Box &queryArea, std::list<float4
     float2 bottomLeft  = float2(queryArea.x - halfSizeX, queryArea.y - halfSizeY);
     float2 bottomRight = float2(queryArea.x + halfSizeX, queryArea.y - halfSizeY);
 
-    queryAreaLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
-    queryAreaLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
-    queryAreaLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
-    queryAreaLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
+    queryAreaLines[0]  = float4(topLeft.x, topLeft.y, topRight.x, topRight.y);
+    queryAreaLines[1]  = float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y);
+    queryAreaLines[2]  = float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y);
+    queryAreaLines[3]  = float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y);
 }

--- a/SobrassadaEngine/UI/QuadtreeViewer.cpp
+++ b/SobrassadaEngine/UI/QuadtreeViewer.cpp
@@ -68,7 +68,7 @@ void QuadtreeViewer::Render(bool &renderBoolean)
     quadtree->GetDrawLines(drawLines, elementLines);
 
     Box queryArea = Box(5, 5, 5, 5);
-    std::unordered_set<Box, BoxHash> rettrievedElements;
+    std::set<Box> rettrievedElements;
     quadtree->QueryElements(queryArea, rettrievedElements);
 
     CreateQueryAreaLines(queryArea, queryAreaLines);

--- a/SobrassadaEngine/UI/QuadtreeViewer.h
+++ b/SobrassadaEngine/UI/QuadtreeViewer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Geometry/Frustum.h"
+#include "Math/float4x4.h"
+#include <list>
+
+class Framebuffer;
+class Quadtree;
+
+struct Box;
+
+class QuadtreeViewer
+{
+  public:
+    QuadtreeViewer();
+    ~QuadtreeViewer();
+
+    void Render(bool &renderBoolean);
+
+  private:
+    void ChangeCameraSize(float width, float height);
+    void CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const;
+
+  private:
+    Framebuffer *framebuffer;
+    Quadtree *quadtree;
+    float cameraSizeScaleFactor = 10.f;
+
+    Frustum camera;
+    float4x4 viewMatrix;
+    float4x4 projectionMatrix;
+};

--- a/SobrassadaEngine/UI/QuadtreeViewer.h
+++ b/SobrassadaEngine/UI/QuadtreeViewer.h
@@ -2,7 +2,7 @@
 
 #include "Geometry/Frustum.h"
 #include "Math/float4x4.h"
-#include <list>
+#include <vector>
 
 class Framebuffer;
 class Quadtree;
@@ -19,7 +19,7 @@ class QuadtreeViewer
 
   private:
     void ChangeCameraSize(float width, float height);
-    void CreateQueryAreaLines(const Box &queryArea, std::list<float4> &queryAreaLines) const;
+    void CreateQueryAreaLines(const Box &queryArea, std::vector<float4> &queryAreaLines) const;
 
   private:
     Framebuffer *framebuffer;

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -1,5 +1,7 @@
 #include "Quadtree.h"
 
+#include <stack>
+
 Quadtree::Quadtree(float2 position, float size, int capacity)
     : position(position), size(size), elementsCapacity(capacity)
 {
@@ -13,7 +15,7 @@ Quadtree::~Quadtree()
     delete bottomRight;
 }
 
-bool Quadtree::InsertElement(const Box &newElement)
+bool Quadtree::InsertElementRecursive(const Box &newElement)
 {
     if (!Intersects(newElement)) return false;
 
@@ -31,20 +33,20 @@ bool Quadtree::InsertElement(const Box &newElement)
             return true;
         }
 
-        Subdivide();
+        SubdivideRecursive();
     }
 
     bool inserted = false;
 
-    if (topLeft->InsertElement(newElement)) inserted = true;
-    if (topRight->InsertElement(newElement)) inserted = true;
-    if (bottomLeft->InsertElement(newElement)) inserted = true;
-    if (bottomRight->InsertElement(newElement)) inserted = true;
+    if (topLeft->InsertElementRecursive(newElement)) inserted = true;
+    if (topRight->InsertElementRecursive(newElement)) inserted = true;
+    if (bottomLeft->InsertElementRecursive(newElement)) inserted = true;
+    if (bottomRight->InsertElementRecursive(newElement)) inserted = true;
 
     return inserted = true;
 }
 
-void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
+void Quadtree::QueryElementsRecursive(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
 {
     if (!Intersects(area)) return;
 
@@ -55,13 +57,13 @@ void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &
 
     if (IsLeaf()) return;
 
-    topLeft->QueryElements(area, foundElements);
-    topRight->QueryElements(area, foundElements);
-    bottomLeft->QueryElements(area, foundElements);
-    bottomRight->QueryElements(area, foundElements);
+    topLeft->QueryElementsRecursive(area, foundElements);
+    topRight->QueryElementsRecursive(area, foundElements);
+    bottomLeft->QueryElementsRecursive(area, foundElements);
+    bottomRight->QueryElementsRecursive(area, foundElements);
 }
 
-void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const
+void Quadtree::GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<float4> &elementLines) const
 {
     if (elements.size() > 0)
     {
@@ -98,11 +100,156 @@ void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &ele
     }
     else
     {
-        topLeft->GetDrawLines(drawLines, elementLines);
-        topRight->GetDrawLines(drawLines, elementLines);
-        bottomLeft->GetDrawLines(drawLines, elementLines);
-        bottomRight->GetDrawLines(drawLines, elementLines);
+        topLeft->GetDrawLinesRecursive(drawLines, elementLines);
+        topRight->GetDrawLinesRecursive(drawLines, elementLines);
+        bottomLeft->GetDrawLinesRecursive(drawLines, elementLines);
+        bottomRight->GetDrawLinesRecursive(drawLines, elementLines);
     }
+}
+
+bool Quadtree::InsertElement(const Box &newElement)
+{
+    bool inserted = false;
+    std::stack<Quadtree *> nodesToVisit;
+    nodesToVisit.push(this);
+
+    while (!nodesToVisit.empty())
+    {
+        Quadtree *currentNode = nodesToVisit.top();
+        nodesToVisit.pop();
+
+        if (currentNode->Intersects(newElement))
+        {
+            if (currentNode->IsLeaf())
+            {
+                if (currentNode->size <= MinimumLeafSize)
+                {
+                    currentNode->elements.push_back(newElement);
+                    inserted = true;
+                }
+                else if (currentNode->elements.size() < elementsCapacity)
+                {
+                    currentNode->elements.push_back(newElement);
+                    inserted = true;
+                }
+                else currentNode->Subdivide();
+            }
+            if (!currentNode->IsLeaf())
+            {
+                nodesToVisit.push(currentNode->topLeft);
+                nodesToVisit.push(currentNode->topRight);
+                nodesToVisit.push(currentNode->bottomLeft);
+                nodesToVisit.push(currentNode->bottomRight);
+            }
+        }
+    }
+
+    return inserted;
+}
+
+void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
+{
+    std::stack<const Quadtree *> nodesToVisit;
+    nodesToVisit.push(this);
+
+    while (!nodesToVisit.empty())
+    {
+        const Quadtree *currentNode = nodesToVisit.top();
+        nodesToVisit.pop();
+
+        if (currentNode->Intersects(area))
+        {
+            if (currentNode->IsLeaf())
+            {
+                for (auto &element : currentNode->elements)
+                {
+                    foundElements.insert(element);
+                }
+            }
+            else
+            {
+                nodesToVisit.push(currentNode->topLeft);
+                nodesToVisit.push(currentNode->topRight);
+                nodesToVisit.push(currentNode->bottomLeft);
+                nodesToVisit.push(currentNode->bottomRight);
+            }
+        }
+    }
+}
+
+void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const
+{
+    std::stack<const Quadtree *> nodesToVisit;
+    nodesToVisit.push(this);
+
+    while (!nodesToVisit.empty())
+    {
+        const Quadtree *currentNode = nodesToVisit.top();
+        nodesToVisit.pop();
+
+        if (currentNode->IsLeaf())
+        {
+
+            float halfSize     = currentNode->size / 2.f;
+
+            float2 topLeft     = float2(currentNode->position.x - halfSize, currentNode->position.y + halfSize);
+            float2 topRight    = float2(currentNode->position.x + halfSize, currentNode->position.y + halfSize);
+            float2 bottomLeft  = float2(currentNode->position.x - halfSize, currentNode->position.y - halfSize);
+            float2 bottomRight = float2(currentNode->position.x + halfSize, currentNode->position.y - halfSize);
+
+            drawLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
+            drawLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
+            drawLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
+            drawLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
+
+            for (auto &element : currentNode->elements)
+            {
+                float halfSizeX = element.sizeX / 2.f;
+                float halfSizeY = element.sizeY / 2.f;
+
+                topLeft         = float2(element.x - halfSizeX, element.y + halfSizeY);
+                topRight        = float2(element.x + halfSizeX, element.y + halfSizeY);
+                bottomLeft      = float2(element.x - halfSizeX, element.y - halfSizeY);
+                bottomRight     = float2(element.x + halfSizeX, element.y - halfSizeY);
+
+                elementLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
+                elementLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
+                elementLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
+                elementLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
+            }
+        }
+        else
+        {
+            nodesToVisit.push(currentNode->topLeft);
+            nodesToVisit.push(currentNode->topRight);
+            nodesToVisit.push(currentNode->bottomLeft);
+            nodesToVisit.push(currentNode->bottomRight);
+        }
+    }
+}
+
+void Quadtree::SubdivideRecursive()
+{
+    float childSize     = size / 2.f;
+    float halfChildSize = size / 4.f;
+
+    topLeft = new Quadtree(float2(position.x - halfChildSize, position.y + halfChildSize), childSize, elementsCapacity);
+    topRight =
+        new Quadtree(float2(position.x + halfChildSize, position.y + halfChildSize), childSize, elementsCapacity);
+    bottomLeft =
+        new Quadtree(float2(position.x - halfChildSize, position.y - halfChildSize), childSize, elementsCapacity);
+    bottomRight =
+        new Quadtree(float2(position.x + halfChildSize, position.y - halfChildSize), childSize, elementsCapacity);
+
+    for (auto &element : elements)
+    {
+        topLeft->InsertElementRecursive(element);
+        topRight->InsertElementRecursive(element);
+        bottomLeft->InsertElementRecursive(element);
+        bottomRight->InsertElementRecursive(element);
+    }
+
+    elements.clear();
 }
 
 void Quadtree::Subdivide()
@@ -120,10 +267,10 @@ void Quadtree::Subdivide()
 
     for (auto &element : elements)
     {
-        topLeft->InsertElement(element);
-        topRight->InsertElement(element);
-        bottomLeft->InsertElement(element);
-        bottomRight->InsertElement(element);
+        if (topLeft->Intersects(element)) topLeft->elements.push_back(element);
+        if (topRight->Intersects(element)) topRight->elements.push_back(element);
+        if (bottomLeft->Intersects(element)) bottomLeft->elements.push_back(element);
+        if (bottomRight->Intersects(element)) bottomRight->elements.push_back(element);
     }
 
     elements.clear();

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -1,0 +1,116 @@
+#include "Quadtree.h"
+
+Quadtree::Quadtree(float2 position, float size, int capacity)
+    : position(position), size(size), elementsCapacity(capacity)
+{
+}
+
+Quadtree::~Quadtree()
+{
+    delete topLeft;
+    delete topRight;
+    delete bottomLeft;
+    delete bottomRight;
+}
+
+bool Quadtree::InsertElement(float4 &newElement)
+{
+    if (!Intersects(newElement)) return false;
+
+    if (IsLeaf())
+    {
+        if (size <= MinimumLeafSize)
+        {
+            elements.push_back(newElement);
+            return true;
+        }
+
+        if (elements.size() < elementsCapacity)
+        {
+            elements.push_back(newElement);
+            return true;
+        }
+
+        Subdivide();
+    }
+
+    bool inserted = false;
+
+    if (topLeft->InsertElement(newElement)) inserted = true;
+    else if (topRight->InsertElement(newElement)) inserted = true;
+    else if (bottomLeft->InsertElement(newElement)) inserted = true;
+    else if (bottomRight->InsertElement(newElement)) inserted = true;
+
+    return inserted = true;
+}
+
+void Quadtree::QueryElements(float4 &area, std::unordered_set<float4> &foundElements)
+{
+}
+
+void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines)
+{
+    if (elements.size() > 0)
+    {
+        for (auto &element : elements)
+        {
+            float sizeX = element.z;
+            float sizeY = element.w;
+
+            elementLines.push_back(float4(element.x, element.y, element.x + sizeX, element.y));
+            elementLines.push_back(float4(element.x + sizeX, element.y, element.x + sizeX, element.y - sizeY));
+            elementLines.push_back(float4(element.x, element.y - sizeY, element.x + sizeX, element.y - sizeY));
+            elementLines.push_back(float4(element.x, element.y, element.x, element.y - sizeY));
+        }
+    }
+
+    if (IsLeaf())
+    {
+        drawLines.push_back(float4(position.x, position.y, position.x + size, position.y));
+        drawLines.push_back(float4(position.x + size, position.y, position.x + size, position.y - size));
+        drawLines.push_back(float4(position.x, position.y - size, position.x + size, position.y - size));
+        drawLines.push_back(float4(position.x, position.y, position.x, position.y - size));
+    }
+    else
+    {
+        topLeft->GetDrawLines(drawLines, elementLines);
+        topRight->GetDrawLines(drawLines, elementLines);
+        bottomLeft->GetDrawLines(drawLines, elementLines);
+        bottomRight->GetDrawLines(drawLines, elementLines);
+    }
+}
+
+void Quadtree::Subdivide()
+{
+    float childSize = size / 2.f;
+
+    topLeft         = new Quadtree(float2(position.x, position.y), childSize, elementsCapacity);
+    topRight        = new Quadtree(float2(position.x + childSize, position.y), childSize, elementsCapacity);
+    bottomLeft      = new Quadtree(float2(position.x, position.y - childSize), childSize, elementsCapacity);
+    bottomRight     = new Quadtree(float2(position.x + childSize, position.y - childSize), childSize, elementsCapacity);
+
+    for (auto &element : elements)
+    {
+        topLeft->InsertElement(element);
+        topRight->InsertElement(element);
+        bottomLeft->InsertElement(element);
+        bottomRight->InsertElement(element);
+    }
+
+    elements.clear();
+}
+
+bool Quadtree::Intersects(float4 &element)
+{
+    float2 l1 = position;
+    float2 r1 = float2(position.x + size, position.y - size);
+
+    float2 l2 = float2(element.x, element.y);
+    float2 r2 = float2(element.x + element.z, element.y - element.w);
+
+    if (l1.x > r2.x || l2.x > r1.x) return false;
+
+    if (r1.y > l2.y || r2.y > l1.y) return false;
+
+    return true;
+}

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -15,95 +15,6 @@ Quadtree::~Quadtree()
     delete bottomRight;
 }
 
-bool Quadtree::InsertElementRecursive(const Box &newElement)
-{
-    if (!Intersects(newElement)) return false;
-
-    if (IsLeaf())
-    {
-        if (size <= MinimumLeafSize)
-        {
-            elements.push_back(newElement);
-            return true;
-        }
-
-        if (elements.size() < elementsCapacity)
-        {
-            elements.push_back(newElement);
-            return true;
-        }
-
-        SubdivideRecursive();
-    }
-
-    bool inserted = false;
-
-    if (topLeft->InsertElementRecursive(newElement)) inserted = true;
-    if (topRight->InsertElementRecursive(newElement)) inserted = true;
-    if (bottomLeft->InsertElementRecursive(newElement)) inserted = true;
-    if (bottomRight->InsertElementRecursive(newElement)) inserted = true;
-
-    return inserted = true;
-}
-
-void Quadtree::QueryElementsRecursive(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
-{
-    if (!Intersects(area)) return;
-
-    for (auto &element : elements)
-    {
-        foundElements.insert(element);
-    }
-
-    if (IsLeaf()) return;
-
-    topLeft->QueryElementsRecursive(area, foundElements);
-    topRight->QueryElementsRecursive(area, foundElements);
-    bottomLeft->QueryElementsRecursive(area, foundElements);
-    bottomRight->QueryElementsRecursive(area, foundElements);
-}
-
-void Quadtree::GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<float4> &elementLines) const
-{
-    if (IsLeaf())
-    {
-        float halfSize     = size / 2.f;
-
-        float2 topLeft     = float2(position.x - halfSize, position.y + halfSize);
-        float2 topRight    = float2(position.x + halfSize, position.y + halfSize);
-        float2 bottomLeft  = float2(position.x - halfSize, position.y - halfSize);
-        float2 bottomRight = float2(position.x + halfSize, position.y - halfSize);
-
-        drawLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
-        drawLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
-        drawLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
-        drawLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
-
-        for (auto &element : elements)
-        {
-            float halfSizeX = element.sizeX / 2.f;
-            float halfSizeY = element.sizeY / 2.f;
-
-            topLeft         = float2(element.x - halfSizeX, element.y + halfSizeY);
-            topRight        = float2(element.x + halfSizeX, element.y + halfSizeY);
-            bottomLeft      = float2(element.x - halfSizeX, element.y - halfSizeY);
-            bottomRight     = float2(element.x + halfSizeX, element.y - halfSizeY);
-
-            elementLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
-            elementLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
-            elementLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
-            elementLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
-        }
-    }
-    else
-    {
-        topLeft->GetDrawLinesRecursive(drawLines, elementLines);
-        topRight->GetDrawLinesRecursive(drawLines, elementLines);
-        bottomLeft->GetDrawLinesRecursive(drawLines, elementLines);
-        bottomRight->GetDrawLinesRecursive(drawLines, elementLines);
-    }
-}
-
 bool Quadtree::InsertElement(const Box &newElement)
 {
     bool inserted = false;
@@ -223,30 +134,6 @@ void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &ele
             nodesToVisit.push(currentNode->bottomRight);
         }
     }
-}
-
-void Quadtree::SubdivideRecursive()
-{
-    float childSize     = size / 2.f;
-    float halfChildSize = size / 4.f;
-
-    topLeft = new Quadtree(float2(position.x - halfChildSize, position.y + halfChildSize), childSize, elementsCapacity);
-    topRight =
-        new Quadtree(float2(position.x + halfChildSize, position.y + halfChildSize), childSize, elementsCapacity);
-    bottomLeft =
-        new Quadtree(float2(position.x - halfChildSize, position.y - halfChildSize), childSize, elementsCapacity);
-    bottomRight =
-        new Quadtree(float2(position.x + halfChildSize, position.y - halfChildSize), childSize, elementsCapacity);
-
-    for (auto &element : elements)
-    {
-        topLeft->InsertElementRecursive(element);
-        topRight->InsertElementRecursive(element);
-        bottomLeft->InsertElementRecursive(element);
-        bottomRight->InsertElementRecursive(element);
-    }
-
-    elements.clear();
 }
 
 void Quadtree::Subdivide()

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -57,7 +57,7 @@ bool Quadtree::InsertElement(const Box &newElement)
     return inserted;
 }
 
-void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
+void Quadtree::QueryElements(const Box &area, std::set<Box> &foundElements) const
 {
     std::stack<const QuadtreeNode *> nodesToVisit;
     nodesToVisit.push(rootNode);
@@ -89,7 +89,7 @@ void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &
 
 void Quadtree::GetDrawLines(std::vector<float4> &drawLines, std::vector<float4> &elementLines) const
 {
-    std::unordered_set<Box, BoxHash> includedElement;
+    std::set<Box> includedElement;
     drawLines    = std::vector<float4>(totalLeaf * 4, float4(0, 0, 0, 0));
     elementLines = std::vector<float4>(totalElements * 4, float4(0, 0, 0, 0));
 

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -13,7 +13,7 @@ Quadtree::~Quadtree()
     delete bottomRight;
 }
 
-bool Quadtree::InsertElement(float4 &newElement)
+bool Quadtree::InsertElement(const Box &newElement)
 {
     if (!Intersects(newElement)) return false;
 
@@ -44,8 +44,21 @@ bool Quadtree::InsertElement(float4 &newElement)
     return inserted = true;
 }
 
-void Quadtree::QueryElements(float4 &area, std::unordered_set<float4> &foundElements) const
+void Quadtree::QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const
 {
+    if (!Intersects(area)) return;
+
+    for (auto &element : elements)
+    {
+        foundElements.insert(element);
+    }
+
+    if (IsLeaf()) return;
+
+    topLeft->QueryElements(area, foundElements);
+    topRight->QueryElements(area, foundElements);
+    bottomLeft->QueryElements(area, foundElements);
+    bottomRight->QueryElements(area, foundElements);
 }
 
 void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const
@@ -54,8 +67,8 @@ void Quadtree::GetDrawLines(std::list<float4> &drawLines, std::list<float4> &ele
     {
         for (auto &element : elements)
         {
-            float halfSizeX    = element.z / 2.f;
-            float halfSizeY    = element.w / 2.f;
+            float halfSizeX    = element.sizeX / 2.f;
+            float halfSizeY    = element.sizeY / 2.f;
 
             float2 topLeft     = float2(element.x - halfSizeX, element.y + halfSizeY);
             float2 topRight    = float2(element.x + halfSizeX, element.y + halfSizeY);
@@ -116,7 +129,7 @@ void Quadtree::Subdivide()
     elements.clear();
 }
 
-bool Quadtree::Intersects(float4 &element) const
+bool Quadtree::Intersects(const Box &element) const
 {
     float halftSizeX          = size / 2.f;
     float halftSizeY          = size / 2.f;
@@ -124,8 +137,8 @@ bool Quadtree::Intersects(float4 &element) const
     float2 selfTopLeft        = float2(position.x - halftSizeX, position.y + halftSizeY);
     float2 selfBottomRight    = float2(position.x + halftSizeX, position.y - halftSizeY);
 
-    halftSizeX                = element.z / 2.f;
-    halftSizeY                = element.w / 2.f;
+    halftSizeX                = element.sizeX / 2.f;
+    halftSizeY                = element.sizeY / 2.f;
 
     float2 elementTopLeft     = float2(element.x - halftSizeX, element.y + halftSizeY);
     float2 elementBottomRight = float2(element.x + halftSizeX, element.y - halftSizeY);

--- a/SobrassadaEngine/Utils/Quadtree.cpp
+++ b/SobrassadaEngine/Utils/Quadtree.cpp
@@ -65,25 +65,6 @@ void Quadtree::QueryElementsRecursive(const Box &area, std::unordered_set<Box, B
 
 void Quadtree::GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<float4> &elementLines) const
 {
-    if (elements.size() > 0)
-    {
-        for (auto &element : elements)
-        {
-            float halfSizeX    = element.sizeX / 2.f;
-            float halfSizeY    = element.sizeY / 2.f;
-
-            float2 topLeft     = float2(element.x - halfSizeX, element.y + halfSizeY);
-            float2 topRight    = float2(element.x + halfSizeX, element.y + halfSizeY);
-            float2 bottomLeft  = float2(element.x - halfSizeX, element.y - halfSizeY);
-            float2 bottomRight = float2(element.x + halfSizeX, element.y - halfSizeY);
-
-            elementLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
-            elementLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
-            elementLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
-            elementLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
-        }
-    }
-
     if (IsLeaf())
     {
         float halfSize     = size / 2.f;
@@ -97,6 +78,22 @@ void Quadtree::GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<flo
         drawLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
         drawLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
         drawLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
+
+        for (auto &element : elements)
+        {
+            float halfSizeX = element.sizeX / 2.f;
+            float halfSizeY = element.sizeY / 2.f;
+
+            topLeft         = float2(element.x - halfSizeX, element.y + halfSizeY);
+            topRight        = float2(element.x + halfSizeX, element.y + halfSizeY);
+            bottomLeft      = float2(element.x - halfSizeX, element.y - halfSizeY);
+            bottomRight     = float2(element.x + halfSizeX, element.y - halfSizeY);
+
+            elementLines.push_back(float4(topLeft.x, topLeft.y, topRight.x, topRight.y));
+            elementLines.push_back(float4(topRight.x, topRight.y, bottomRight.x, bottomRight.y));
+            elementLines.push_back(float4(bottomLeft.x, bottomLeft.y, bottomRight.x, bottomRight.y));
+            elementLines.push_back(float4(topLeft.x, topLeft.y, bottomLeft.x, bottomLeft.y));
+        }
     }
     else
     {

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -10,6 +10,31 @@
 
 constexpr int MinimumLeafSize = 2;
 
+struct Box
+{
+    float x;
+    float y;
+
+    float sizeX;
+    float sizeY;
+
+    Box(float x, float y, float sizeX, float sizeY) : x(x), y(y), sizeX(sizeX), sizeY(sizeY) {};
+
+    bool operator==(const Box &otherBox) const
+    {
+        return (x == otherBox.x && y == otherBox.y && sizeX == otherBox.sizeX && sizeY == otherBox.sizeY);
+    }
+};
+
+struct BoxHash
+{
+    auto operator()(const Box &box) const -> size_t
+    {
+        return std::hash<float> {}(box.x) ^ std::hash<float> {}(box.y) ^ std::hash<float> {}(box.sizeX) ^
+               std::hash<float> {}(box.sizeY);
+    }
+};
+
 // TODO: CHANGE TO TEMPLATE CLASS
 // TODO: CHANGE TO OBB
 class Quadtree
@@ -18,13 +43,13 @@ class Quadtree
     Quadtree(float2 position, float size, int capacity);
     ~Quadtree();
 
-    bool InsertElement(float4 &newElement);
-    void QueryElements(float4 &area, std::unordered_set<float4> &foundElements) const;
+    bool InsertElement(const Box &newElement);
+    void QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
     void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
 
   private:
     void Subdivide();
-    bool Intersects(float4 &element) const;
+    bool Intersects(const Box &element) const;
     bool IsLeaf() const { return topLeft == nullptr; };
 
   private:
@@ -33,7 +58,7 @@ class Quadtree
     int elementsCapacity;
 
     // TODO: CHANGE TO TEMPLATE CLASS
-    std::vector<float4> elements;
+    std::vector<Box> elements;
 
     Quadtree *topLeft     = nullptr;
     Quadtree *topRight    = nullptr;

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Math/float2.h"
+#include "Math/float3.h"
+#include "Math/float4.h"
+
+#include <list>
+#include <unordered_set>
+#include <vector>
+
+constexpr int MinimumLeafSize = 2;
+
+// TODO: CHANGE TO TEMPLATE CLASS
+// TODO: CHANGE TO OBB
+class Quadtree
+{
+  public:
+    Quadtree(float2 position, float size, int capacity);
+    ~Quadtree();
+
+    bool InsertElement(float4 &newElement);
+    void QueryElements(float4 &area, std::unordered_set<float4> &foundElements);
+    void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines);
+
+  private:
+    void Subdivide();
+    bool Intersects(float4 &element);
+    bool IsLeaf() { return topLeft == nullptr; };
+
+  private:
+    float2 position;
+    float size;
+    int elementsCapacity;
+
+    // TODO: CHANGE TO TEMPLATE CLASS
+    std::vector<float4> elements;
+
+    Quadtree *topLeft     = nullptr;
+    Quadtree *topRight    = nullptr;
+    Quadtree *bottomLeft  = nullptr;
+    Quadtree *bottomRight = nullptr;
+};

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -4,7 +4,6 @@
 #include "Math/float3.h"
 #include "Math/float4.h"
 
-#include <list>
 #include <unordered_set>
 #include <vector>
 
@@ -37,28 +36,43 @@ struct BoxHash
 
 class Quadtree
 {
+  private:
+    class QuadtreeNode
+    {
+      public:
+        QuadtreeNode() = default;
+        QuadtreeNode(float2 position, float size, int capacity)
+            : position(position), size(size), elementsCapacity(capacity) {};
+
+        ~QuadtreeNode();
+
+        void Subdivide();
+        bool Intersects(const Box &element) const;
+        bool IsLeaf() const { return topLeft == nullptr; };
+
+        float2 position      = float2(0, 0);
+        float size           = 1;
+        int elementsCapacity = 0;
+
+        std::vector<Box> elements;
+
+        QuadtreeNode *topLeft     = nullptr;
+        QuadtreeNode *topRight    = nullptr;
+        QuadtreeNode *bottomLeft  = nullptr;
+        QuadtreeNode *bottomRight = nullptr;
+    };
+
   public:
     Quadtree(float2 position, float size, int capacity);
     ~Quadtree();
 
     bool InsertElement(const Box &newElement);
     void QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
-    void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
+    void GetDrawLines(std::vector<float4> &drawLines, std::vector<float4> &elementLines) const;
 
   private:
-    void Subdivide();
-    bool Intersects(const Box &element) const;
-    bool IsLeaf() const { return topLeft == nullptr; };
+    QuadtreeNode *rootNode;
 
-  private:
-    float2 position;
-    float size;
-    int elementsCapacity;
-
-    std::vector<Box> elements;
-
-    Quadtree *topLeft     = nullptr;
-    Quadtree *topRight    = nullptr;
-    Quadtree *bottomLeft  = nullptr;
-    Quadtree *bottomRight = nullptr;
+    int totalLeaf     = 0;
+    int totalElements = 0;
 };

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -4,33 +4,33 @@
 #include "Math/float3.h"
 #include "Math/float4.h"
 
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 constexpr int MinimumLeafSize = 2;
 
 struct Box
 {
-    float x;
-    float y;
+    float x = 0;
+    float y = 0;
 
-    float sizeX;
-    float sizeY;
+    float sizeX = 0;
+    float sizeY = 0;
 
+    Box() = default;
     Box(float x, float y, float sizeX, float sizeY) : x(x), y(y), sizeX(sizeX), sizeY(sizeY) {};
 
     bool operator==(const Box &otherBox) const
     {
         return (x == otherBox.x && y == otherBox.y && sizeX == otherBox.sizeX && sizeY == otherBox.sizeY);
     }
-};
 
-struct BoxHash
-{
-    auto operator()(const Box &box) const -> size_t
+    bool operator<(const Box& otherBox) const
     {
-        return std::hash<float> {}(box.x) ^ std::hash<float> {}(box.y) ^ std::hash<float> {}(box.sizeX) ^
-               std::hash<float> {}(box.sizeY);
+        if (x < otherBox.x) return true;
+        else if (x == otherBox.x && y < otherBox.y) return true;
+
+        return false;
     }
 };
 
@@ -67,7 +67,7 @@ class Quadtree
     ~Quadtree();
 
     bool InsertElement(const Box &newElement);
-    void QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
+    void QueryElements(const Box &area, std::set<Box> &foundElements) const;
     void GetDrawLines(std::vector<float4> &drawLines, std::vector<float4> &elementLines) const;
 
   private:

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -41,16 +41,11 @@ class Quadtree
     Quadtree(float2 position, float size, int capacity);
     ~Quadtree();
 
-    bool InsertElementRecursive(const Box &newElement);
-    void QueryElementsRecursive(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
-    void GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
-
     bool InsertElement(const Box &newElement);
     void QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
     void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
 
   private:
-    void SubdivideRecursive();
     void Subdivide();
     bool Intersects(const Box &element) const;
     bool IsLeaf() const { return topLeft == nullptr; };

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -19,13 +19,13 @@ class Quadtree
     ~Quadtree();
 
     bool InsertElement(float4 &newElement);
-    void QueryElements(float4 &area, std::unordered_set<float4> &foundElements);
-    void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines);
+    void QueryElements(float4 &area, std::unordered_set<float4> &foundElements) const;
+    void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
 
   private:
     void Subdivide();
-    bool Intersects(float4 &element);
-    bool IsLeaf() { return topLeft == nullptr; };
+    bool Intersects(float4 &element) const;
+    bool IsLeaf() const { return topLeft == nullptr; };
 
   private:
     float2 position;

--- a/SobrassadaEngine/Utils/Quadtree.h
+++ b/SobrassadaEngine/Utils/Quadtree.h
@@ -35,19 +35,22 @@ struct BoxHash
     }
 };
 
-// TODO: CHANGE TO TEMPLATE CLASS
-// TODO: CHANGE TO OBB
 class Quadtree
 {
   public:
     Quadtree(float2 position, float size, int capacity);
     ~Quadtree();
 
+    bool InsertElementRecursive(const Box &newElement);
+    void QueryElementsRecursive(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
+    void GetDrawLinesRecursive(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
+
     bool InsertElement(const Box &newElement);
     void QueryElements(const Box &area, std::unordered_set<Box, BoxHash> &foundElements) const;
     void GetDrawLines(std::list<float4> &drawLines, std::list<float4> &elementLines) const;
 
   private:
+    void SubdivideRecursive();
     void Subdivide();
     bool Intersects(const Box &element) const;
     bool IsLeaf() const { return topLeft == nullptr; };
@@ -57,7 +60,6 @@ class Quadtree
     float size;
     int elementsCapacity;
 
-    // TODO: CHANGE TO TEMPLATE CLASS
     std::vector<Box> elements;
 
     Quadtree *topLeft     = nullptr;


### PR DESCRIPTION
Added Quadtree and Quadtree Viewer. When running the engine a new viewport appears with a quadtree rendered, it can be closed and reopened under General tab in the menu.

How to test:

Check functions and change parameters inside QuadtreeViewer inside the UI filter, there is the creation of the quadtree and the insertion of points, as well as the draw call.