### PR TITLE
bug/loadTwice THO-177

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -105,14 +105,15 @@ void MeshComponent::AddMesh(UID resource, bool reloadAABB)
 {
     if (resource == CONSTANT_EMPTY_UID) return;
 
+    if (currentMesh != nullptr)
+    {
+        if (currentMesh->GetUID() == resource) return;
+    }
+
     ResourceMesh* newMesh = dynamic_cast<ResourceMesh*>(App->GetResourcesModule()->RequestResource(resource));
     if (newMesh != nullptr)
     {
-        if (currentMesh != nullptr)
-        {
-            if (currentMesh->GetUID() != newMesh->GetUID()) App->GetResourcesModule()->ReleaseResource(currentMesh);
-        }
-
+        App->GetResourcesModule()->ReleaseResource(currentMesh);
         newMesh->SetMaterial(currentMaterial != nullptr ? currentMaterial->GetUID() : CONSTANT_EMPTY_UID);
         currentMeshName    = newMesh->GetName();
         currentMesh        = newMesh;
@@ -132,6 +133,11 @@ void MeshComponent::AddMesh(UID resource, bool reloadAABB)
 
 void MeshComponent::AddMaterial(UID resource)
 {
+    if (currentMaterial != nullptr)
+    {
+        if (currentMaterial->GetUID() == resource) return;
+    }
+
     ResourceMaterial* newMaterial =
         dynamic_cast<ResourceMaterial*>(App->GetResourcesModule()->RequestResource(resource));
     if (newMaterial != nullptr)

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -108,7 +108,11 @@ void MeshComponent::AddMesh(UID resource, bool reloadAABB)
     ResourceMesh* newMesh = dynamic_cast<ResourceMesh*>(App->GetResourcesModule()->RequestResource(resource));
     if (newMesh != nullptr)
     {
-        App->GetResourcesModule()->ReleaseResource(currentMesh);
+        if (currentMesh != nullptr)
+        {
+            if (currentMesh->GetUID() != newMesh->GetUID()) App->GetResourcesModule()->ReleaseResource(currentMesh);
+        }
+
         newMesh->SetMaterial(currentMaterial != nullptr ? currentMaterial->GetUID() : CONSTANT_EMPTY_UID);
         currentMeshName    = newMesh->GetName();
         currentMesh        = newMesh;

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -105,10 +105,7 @@ void MeshComponent::AddMesh(UID resource, bool reloadAABB)
 {
     if (resource == CONSTANT_EMPTY_UID) return;
 
-    if (currentMesh != nullptr)
-    {
-        if (currentMesh->GetUID() == resource) return;
-    }
+    if (currentMesh != nullptr && currentMesh->GetUID() == resource) return;
 
     ResourceMesh* newMesh = dynamic_cast<ResourceMesh*>(App->GetResourcesModule()->RequestResource(resource));
     if (newMesh != nullptr)
@@ -133,10 +130,7 @@ void MeshComponent::AddMesh(UID resource, bool reloadAABB)
 
 void MeshComponent::AddMaterial(UID resource)
 {
-    if (currentMaterial != nullptr)
-    {
-        if (currentMaterial->GetUID() == resource) return;
-    }
+    if (currentMaterial != nullptr && currentMaterial->GetUID() == resource) return;
 
     ResourceMaterial* newMaterial =
         dynamic_cast<ResourceMaterial*>(App->GetResourcesModule()->RequestResource(resource));

--- a/SobrassadaEngine/Utils/LightsConfig.cpp
+++ b/SobrassadaEngine/Utils/LightsConfig.cpp
@@ -268,6 +268,7 @@ void LightsConfig::AddDirectionalLight(DirectionalLight* newDirectional)
 {
     if (directionalLight == nullptr) directionalLight = newDirectional;
 }
+
 void LightsConfig::AddPointLight(PointLight* newPoint)
 {
     // Add point light to vector and resize buffer
@@ -282,13 +283,15 @@ void LightsConfig::AddPointLight(PointLight* newPoint)
         bufferSize
     );
 }
+
 void LightsConfig::AddSpotLight(SpotLight* newSpot)
 {
     spotLights.push_back(newSpot);
 
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, spotBufferId);
-    int bufferSize =
-        static_cast<int>((sizeof(Lights::SpotLightShaderData) + 12) * spotLights.size() + 16); // 12 bytes offset between spotlights
+    int bufferSize = static_cast<int>(
+        (sizeof(Lights::SpotLightShaderData) + 12) * spotLights.size() + 16
+    ); // 12 bytes offset between spotlights
     glBufferData(GL_SHADER_STORAGE_BUFFER, bufferSize, nullptr, GL_STATIC_DRAW);
 
     GLOG(
@@ -324,6 +327,7 @@ void LightsConfig::RemovePointLight(UID pointUid)
 
     GLOG("Point lights size: %d. Buffer size: %d", pointLights.size(), bufferSize);
 }
+
 void LightsConfig::RemoveSpotLight(UID spotUid)
 {
     GLOG("Remove spot light with UID: %d", spotUid);
@@ -341,8 +345,9 @@ void LightsConfig::RemoveSpotLight(UID spotUid)
 
     // Resize lights buffer
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, spotBufferId);
-    int bufferSize =
-        static_cast<int>((sizeof(Lights::SpotLightShaderData) + 12) * spotLights.size() + 16); // 12 bytes offset between spotlights
+    int bufferSize = static_cast<int>(
+        (sizeof(Lights::SpotLightShaderData) + 12) * spotLights.size() + 16
+    ); // 12 bytes offset between spotlights
     glBufferData(GL_SHADER_STORAGE_BUFFER, bufferSize, nullptr, GL_STATIC_DRAW);
 
     GLOG("Spot lights size: %d. Buffer size: %d", spotLights.size(), bufferSize);

--- a/SobrassadaEngine/Utils/Scene.cpp
+++ b/SobrassadaEngine/Utils/Scene.cpp
@@ -42,14 +42,14 @@ Scene::~Scene()
     delete sceneOctree;
     lightsConfig = nullptr;
 
-    GLOG("%s scene closed", sceneName)
+    GLOG("%s scene closed", sceneName.c_str());
 }
 
 void Scene::Save() const
 {
     if (!App->GetLibraryModule()->SaveScene(SCENES_PATH, SaveMode::Save))
     {
-        GLOG("%s scene saving failed", sceneName)
+        GLOG("%s scene saving failed", sceneName.c_str());
     }
 }
 
@@ -72,7 +72,7 @@ void Scene::LoadGameObjects(const std::unordered_map<UID, GameObject*>& loadedGa
     GameObject* root = GetGameObjectByUUID(gameObjectRootUUID);
     if (root != nullptr)
     {
-        GLOG("Init transform and AABB calculation")
+        GLOG("Init transform and AABB calculation");
         root->ComponentGlobalTransformUpdated();
     }
 


### PR DESCRIPTION
Fixed loading twice a mesh or material crashed the application. 
Also, I was debugging and thinking that if we close the scene, all resources should be deleted.