### PR TITLE
Fixed bug with wrong resource reference count

### DIFF
--- a/SobrassadaEngine/Modules/ResourcesModule.cpp
+++ b/SobrassadaEngine/Modules/ResourcesModule.cpp
@@ -78,6 +78,7 @@ Resource* ResourcesModule::CreateNewResource(UID uid)
     if (loadedResource != nullptr)
     {
         resources.insert(std::pair(uid, loadedResource));
+        loadedResource->AddReference();
         return loadedResource;
     }
     return nullptr;


### PR DESCRIPTION
When a resource is created and returned its reference count was not incremented. That led to the issue that is described in the bug report