### PR TITLE
Fixed memory leaks in EngineConfig and ComponentUtils - THO-224

### DIFF
--- a/SobrassadaEngine/Application.cpp
+++ b/SobrassadaEngine/Application.cpp
@@ -16,6 +16,7 @@
 #include "ShaderModule.h"
 #include "WindowModule.h"
 #include "UserInterfaceModule.h"
+#include "ComponentUtils.h"
 
 #ifdef _DEBUG
 #include "optick.h"
@@ -49,6 +50,8 @@ Application::~Application()
     {
         delete *it;
     }
+    delete engineConfig;
+    engineConfig = nullptr;
 }
 
 bool Application::Init()

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -28,6 +28,14 @@
 
 EditorUIModule::EditorUIModule() : width(0), height(0)
 {
+    standaloneComponents = {
+        {"Mesh",              COMPONENT_MESH             },
+        {"Point Light",       COMPONENT_POINT_LIGHT      },
+        {"Spot Light",        COMPONENT_SPOT_LIGHT       },
+        {"Directional Light", COMPONENT_DIRECTIONAL_LIGHT},
+        {"Character Controller", COMPONENT_CHARACTER_CONTROLLER},
+        {"Camera",            COMPONENT_CAMERA           }
+    };
 }
 
 EditorUIModule::~EditorUIModule()
@@ -37,6 +45,7 @@ EditorUIModule::~EditorUIModule()
         delete values.second;
     }
     openEditors.clear();
+    standaloneComponents.clear();
 }
 
 bool EditorUIModule::Init()

--- a/SobrassadaEngine/Modules/EditorUIModule.h
+++ b/SobrassadaEngine/Modules/EditorUIModule.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <unordered_map>
 // imguizmo include after imgui
+#include "ComponentUtils.h"
 #include "./Libs/ImGuizmo/ImGuizmo.h"
 
 enum EditorType
@@ -75,7 +76,12 @@ class EditorUIModule : public Module
     float3& GetSnapValues() { return snapValues; }
     GizmoDragState GetImGuizmoDragState() const { return guizmoDragState; };
 
-  private:
+    const std::unordered_map<std::string, ComponentType>& GetStandaloneComponents() const
+    {
+        return standaloneComponents;
+    }
+
+private:
     void RenderBasicTransformModifiers(
         float3& outputPosition, float3& outputRotation, float3& outputScale, bool& lockScaleAxis,
         bool& positionValueChanged, bool& rotationValueChanged, bool& scaleValueChanged
@@ -142,4 +148,5 @@ class EditorUIModule : public Module
 
     float3 snapValues                    = {1.f, 1.f, 1.f};
     std::unordered_map<UID, EngineEditorBase*> openEditors;
+    std::unordered_map<std::string, ComponentType> standaloneComponents;
 };

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -26,15 +26,6 @@ enum ComponentType
     LAST  = COMPONENT_CAMERA
 };
 
-static const std::unordered_map<std::string, ComponentType> standaloneComponents = {
-    {"Mesh",              COMPONENT_MESH             },
-    {"Point Light",       COMPONENT_POINT_LIGHT      },
-    {"Spot Light",        COMPONENT_SPOT_LIGHT       },
-    {"Directional Light", COMPONENT_DIRECTIONAL_LIGHT},
-    {"Character Controller", COMPONENT_CHARACTER_CONTROLLER},
-    {"Camera",            COMPONENT_CAMERA           }
-};
-
 class ComponentUtils
 {
   public:

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -185,7 +185,7 @@ void GameObject::RenderEditorInspector()
         }
 
         auto selectedType = App->GetEditorUIModule()->RenderResourceSelectDialog<ComponentType>(
-            "ComponentSelection", standaloneComponents, COMPONENT_NONE
+            "ComponentSelection", App->GetEditorUIModule()->GetStandaloneComponents(), COMPONENT_NONE
         );
         if (selectedType != COMPONENT_NONE)
         {


### PR DESCRIPTION
Fixed two memory leaks. 
- EngineConfig did not get deleted
- static list in ComponentUtils showed as memory leak, according to Marc its an issue in the vs debugger. Still removed it though