### PR TITLE
Update keys mov character controller tho 324

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -196,13 +196,24 @@ void CharacterControllerComponent::HandleInput(float deltaTime)
 
     float3 direction(0.0f, 0.0f, 0.0f);
 
+    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT || keyboard[SDL_SCANCODE_D] == KEY_REPEAT)
+    {
+        targetDirection.Set(1.0f, 0.0f, 0.0f);
+    }
+    else
+    {
+        targetDirection.Set(0.0f, 0.0f, 1.0f);
+    }
+
     if (keyboard[SDL_SCANCODE_W] == KEY_REPEAT) direction -= targetDirection;
     if (keyboard[SDL_SCANCODE_S] == KEY_REPEAT) direction += targetDirection;
+    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) direction -= targetDirection;
+    if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) direction += targetDirection;
 
     float rotationDir = 0.0f;
 
-    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) rotationDir += 1.0f;
-    if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) rotationDir -= 1.0f;
+    if (keyboard[SDL_SCANCODE_Q] == KEY_REPEAT) rotationDir += 1.0f;
+    if (keyboard[SDL_SCANCODE_E] == KEY_REPEAT) rotationDir -= 1.0f;
 
     if (direction.LengthSq() > 0.0001f)
     {

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -196,19 +196,10 @@ void CharacterControllerComponent::HandleInput(float deltaTime)
 
     float3 direction(0.0f, 0.0f, 0.0f);
 
-    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT || keyboard[SDL_SCANCODE_D] == KEY_REPEAT)
-    {
-        targetDirection.Set(1.0f, 0.0f, 0.0f);
-    }
-    else
-    {
-        targetDirection.Set(0.0f, 0.0f, 1.0f);
-    }
-
-    if (keyboard[SDL_SCANCODE_W] == KEY_REPEAT) direction -= targetDirection;
-    if (keyboard[SDL_SCANCODE_S] == KEY_REPEAT) direction += targetDirection;
-    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) direction -= targetDirection;
-    if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) direction += targetDirection;
+    if (keyboard[SDL_SCANCODE_W] == KEY_REPEAT) direction.z -= 1.0f;
+    if (keyboard[SDL_SCANCODE_S] == KEY_REPEAT) direction.z += 1.0f;
+    if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) direction.x -= 1.0f;
+    if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) direction.x += 1.0f;
 
     float rotationDir = 0.0f;
 
@@ -218,6 +209,9 @@ void CharacterControllerComponent::HandleInput(float deltaTime)
     if (direction.LengthSq() > 0.0001f)
     {
         direction.Normalize();
+        targetDirection = direction;
+
+        // TODO: Handle rotation of gameObject when changing directions (target direction will be used in this part)
         Move(direction, deltaTime);
     }
 


### PR DESCRIPTION
Added movement in X-axis as a request from the art team. Now keys "A" and "D" makes horizontal movements.

To mahe coherence with rotation, now rotation keys are binded with "Q" (rotate left) and "E" (rotate right).

In order to test this, create a gameObject with a mesh component as a child and the parent should have the character Controller component. Once in play mode, play with WASDQE keys.

NOTE: Has been found a bug when play button is pressed and afterwards  stop button is pressed more than once, it unables to execute the engine. To solve this, you are forced to delete the save scene that was using. It is unknown if this bug has been solved in VS2 branch.