### PR TITLE
THO-334 Multiple Selection

### DIFF
--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -694,7 +694,7 @@ void DebugDrawModule::DrawLine(
     dd::line(origin, dir + origin, color, 0, enableDepth);
 }
 
-// TODO, CHECK IF PROPER WAY OF IMPLEMENTATION
+
 void DebugDrawModule::DrawLine(const btVector3& from, const btVector3& to, const btVector3& color)
 {
     dd::line(

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -94,18 +94,22 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 keyboard[SDL_SCANCODE_LSHIFT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
+                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(),
+                    loadedScene->GetDynamicTree()
                 );
 
                 if (selectedObject != nullptr)
                 {
+                    if (!loadedScene->IsMultiselecting()) loadedScene->SetMultiselectPosition(selectedObject->GetPosition());
+
                     loadedScene->AddGameObjectToSelection(selectedObject->GetUID(), selectedObject->GetParent());
                 }
             }
             else if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
+                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(),
+                    loadedScene->GetDynamicTree()
                 );
 
                 if (selectedObject != nullptr)

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -90,7 +90,19 @@ update_status SceneModule::PostUpdate(float deltaTime)
         {
             const KeyState* mouseButtons = App->GetInputModule()->GetMouseButtons();
             const KeyState* keyboard     = App->GetInputModule()->GetKeyboard();
-            if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
+            if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT] &&
+                keyboard[SDL_SCANCODE_LSHIFT])
+            {
+                GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
+                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
+                );
+
+                if (selectedObject != nullptr)
+                {
+                    loadedScene->AddGameObjectToSelection(selectedObject->GetUID(), selectedObject->GetParent());
+                }
+            }
+            else if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
                     App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
@@ -99,6 +111,7 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 if (selectedObject != nullptr)
                 {
                     loadedScene->SetSelectedGameObject(selectedObject->GetUID());
+                    loadedScene->ClearObjectSelection();
                 }
             }
         }

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -94,13 +94,13 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 keyboard[SDL_SCANCODE_LSHIFT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(),
-                    loadedScene->GetDynamicTree()
+                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
                 );
 
                 if (selectedObject != nullptr)
                 {
-                    if (!loadedScene->IsMultiselecting()) loadedScene->SetMultiselectPosition(selectedObject->GetPosition());
+                    if (!loadedScene->IsMultiselecting())
+                        loadedScene->SetMultiselectPosition(selectedObject->GetPosition());
 
                     loadedScene->AddGameObjectToSelection(selectedObject->GetUID(), selectedObject->GetParent());
                 }
@@ -108,8 +108,7 @@ update_status SceneModule::PostUpdate(float deltaTime)
             else if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(),
-                    loadedScene->GetDynamicTree()
+                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
                 );
 
                 if (selectedObject != nullptr)
@@ -135,6 +134,9 @@ update_status SceneModule::PostUpdate(float deltaTime)
 
             loadedScene->UpdateGameObjects();
         }
+
+        // IF SCENE NOT FOCUSED AND WAS MULTISELECTING RELEASE
+        if (loadedScene->IsMultiselecting() && !loadedScene->IsSceneFocused()) loadedScene->ClearObjectSelection();
 
         if (loadedScene->GetStopPlaying()) SwitchPlayMode(false);
     }

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -111,11 +111,9 @@ update_status SceneModule::PostUpdate(float deltaTime)
                     App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
                 );
 
-                if (selectedObject != nullptr)
-                {
-                    loadedScene->SetSelectedGameObject(selectedObject->GetUID());
-                    loadedScene->ClearObjectSelection();
-                }
+                if (selectedObject != nullptr) loadedScene->SetSelectedGameObject(selectedObject->GetUID());
+
+                loadedScene->ClearObjectSelection();
             }
         }
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -395,6 +395,10 @@ void GameObject::OnTransformUpdated()
     globalOBB                    = globalTransform * OBB(localAABB);
     globalAABB                   = AABB(globalOBB);
 
+    position                     = globalTransform.TranslatePart();
+    rotation                     = globalTransform.RotatePart().ToEulerXYZ();
+    scale                        = globalTransform.GetScale();
+
     MeshComponent* meshComponent = GetMeshComponent();
     if (meshComponent != nullptr)
     {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -64,9 +64,7 @@ GameObject::GameObject(const rapidjson::Value& initialState) : uid(initialState[
     name                   = initialState["Name"].GetString();
     selectedComponentIndex = COMPONENT_NONE;
     mobilitySettings       = initialState["Mobility"].GetInt();
-    if (initialState.HasMember("IsTopParent")) 
-        isTopParent = initialState["IsTopParent"].GetBool();
-   
+    if (initialState.HasMember("IsTopParent")) isTopParent = initialState["IsTopParent"].GetBool();
 
     if (initialState.HasMember("PrefabUID")) prefabUID = initialState["PrefabUID"].GetUint64();
 
@@ -433,7 +431,7 @@ AABB GameObject::GetHierarchyAABB()
     std::set<UID> visitedGameObjects;
     std::stack<UID> toVisitGameObjects;
     UID sceneRootUID = App->GetSceneModule()->GetScene()->GetGameObjectRootUID();
-    // ADD "THIS" GAME OBJECT SO WHEN ASCENDING HERIARCHY WE DON'T REVISIT OUR CHILDREN
+
     visitedGameObjects.insert(uid);
 
     // FIRST UPDATE DOWN THE HERIARCHY
@@ -450,7 +448,7 @@ AABB GameObject::GetHierarchyAABB()
             visitedGameObjects.insert(currentUID);
             const GameObject* currentGameObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(currentUID);
 
-            const AABB& currentAABB       = currentGameObject->GetGlobalAABB();
+            const AABB& currentAABB             = currentGameObject->GetGlobalAABB();
             if (currentAABB.IsFinite() && !currentAABB.IsDegenerate())
                 returnAABB.Enclose(currentGameObject->GetGlobalAABB());
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -81,6 +81,9 @@ class SOBRASADA_API_ENGINE GameObject
     // Updates the transform for this game object and all descending children
     void UpdateTransformForGOBranch();
     void UpdateMobilityHierarchy(MobilitySettings type);
+    void UpdateLocalTransform(const float4x4& parentGlobalTransform);
+
+    bool WillUpdate() const { return willUpdate; };
 
     const std::unordered_map<ComponentType, Component*>& GetComponents() const { return components; }
     Component* GetComponentByType(ComponentType type) const;
@@ -103,9 +106,7 @@ class SOBRASADA_API_ENGINE GameObject
 
     void SetPosition(const float3& newPosition) { position = newPosition; };
     void SetWillUpdate(bool willUpdate) { this->willUpdate = willUpdate; };
-    bool WillUpdate() const { return willUpdate; };
 
-    void UpdateLocalTransform(const float4x4& parentGlobalTransform);
   private:
     void DrawNodes() const;
     void OnDrawConnectionsToggle();

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -101,12 +101,12 @@ class SOBRASADA_API_ENGINE GameObject
     void UpdateComponents();
     AABB GetHierarchyAABB();
 
-    void SetPosition(float3& newPosition) { position = newPosition; };
+    void SetPosition(const float3& newPosition) { position = newPosition; };
     void SetWillUpdate(bool willUpdate) { this->willUpdate = willUpdate; };
     bool WillUpdate() const { return willUpdate; };
 
-  private:
     void UpdateLocalTransform(const float4x4& parentGlobalTransform);
+  private:
     void DrawNodes() const;
     void OnDrawConnectionsToggle();
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -654,7 +654,7 @@ void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
         GameObject* selectedGameObject       = GetGameObjectByUID(gameObject);
         GameObject* selectedGameObjectParent = GetGameObjectByUID(gameObjectParent);
 
-        selectedGameObjectParent->RemoveGameObject(gameObject);
+        //selectedGameObjectParent->RemoveGameObject(gameObject);
 
         multiSelectParent->AddGameObject(gameObject);
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -303,7 +303,7 @@ update_status Scene::Render(float deltaTime)
     {
         GameObject* gameObject = GetGameObjectByUID(gameObjectIterator.first);
 
-        AABB aabb              = gameObject->GetHierarchyAABB();
+        const AABB aabb              = gameObject->GetHierarchyAABB();
         
         for (int i = 0; i < 12; ++i)
             debugDraw->DrawLineSegment(aabb.Edge(i), float3(1.f, 1.0f, 0.5f));
@@ -725,7 +725,7 @@ UID Scene::GetMultiselectUID() const
 
 void Scene::SetMultiselectPosition(const float3& newPosition)
 {
-    float4x4 localMat = float4x4::FromTRS(newPosition, float4x4::identity, float3::one);
+    const float4x4 localMat = float4x4::FromTRS(newPosition, float4x4::identity, float3::one);
     multiSelectParent->SetLocalTransform(localMat);
 }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -457,6 +457,8 @@ void Scene::RenderScene()
         (ImGui::IsMouseClicked(ImGuiMouseButton_Right) || ImGui::IsMouseClicked(ImGuiMouseButton_Middle)))
         ImGui::SetWindowFocus();
 
+    isFocused = ImGui::IsWindowFocused(ImGuiFocusedFlags_DockHierarchy);
+
     // do inputs only if window is focused
     if (ImGui::IsWindowHovered(ImGuiFocusedFlags_DockHierarchy))
     {

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -249,7 +249,7 @@ update_status Scene::Update(float deltaTime)
     return UPDATE_CONTINUE;
 }
 
-update_status Scene::Render(float deltaTime) const
+update_status Scene::Render(float deltaTime)
 {
     if (!App->GetDebugDrawModule()->GetDebugOptionValue((int)DebugOptions::RENDER_WIREFRAME))
         lightsConfig->RenderSkybox();
@@ -295,6 +295,18 @@ update_status Scene::Render(float deltaTime) const
         {
             gameObject.second->DrawGizmos();
         }
+    }
+
+    DebugDrawModule* debugDraw = App->GetDebugDrawModule();
+
+    for (auto& gameObjectIterator : selectedGameObjects)
+    {
+        GameObject* gameObject = GetGameObjectByUID(gameObjectIterator.first);
+
+        AABB aabb              = gameObject->GetHierarchyAABB();
+        
+        for (int i = 0; i < 12; ++i)
+            debugDraw->DrawLineSegment(aabb.Edge(i), float3(1.f, 1.0f, 0.5f));
     }
 
     return UPDATE_CONTINUE;
@@ -667,6 +679,7 @@ void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
             selectedGameObject->UpdateLocalTransform(selectedGameObjectParent->GetGlobalTransform());
             selectedGameObject->UpdateTransformForGOBranch();
         }
+
         selectedGameObjects.erase(pairResult.first);
     }
 }

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -687,6 +687,12 @@ const std::vector<Component*> Scene::GetAllComponents() const
     return collectedComponents;
 }
 
+void Scene::SetMultiselectPosition(const float3& newPosition)
+{
+    float4x4 localMat = float4x4::FromTRS(newPosition, float4x4::identity, float3::one);
+    multiSelectParent->SetLocalTransform(localMat);
+}
+
 void Scene::CreateStaticSpatialDataStruct()
 {
     // PARAMETRIZED IN FUTURE

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -89,6 +89,8 @@ Scene::~Scene()
     }
     gameObjectsContainer.clear();
 
+    selectedGameObjects.clear();
+
     delete lightsConfig;
     delete sceneOctree;
     delete dynamicTree;
@@ -626,6 +628,11 @@ void Scene::UpdateGameObjects()
 
     }
     gameObjectsToUpdate.clear();
+}
+
+void Scene::ClearObjectSelection()
+{
+    selectedGameObjects.clear();
 }
 
 const std::vector<Component*> Scene::GetAllComponents() const

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -419,7 +419,7 @@ void Scene::RenderEditorControl(bool& editorControlMenu)
                     App->GetDebugDrawModule()->FlipDebugOptionValue(i);
                     if (i == (int)DebugOptions::RENDER_WIREFRAME)
                         App->GetOpenGLModule()->SetRenderWireframe(currentBitValue);
-                    else if(i == (int)DebugOptions::RENDER_PHYSICS_WORLD)
+                    else if (i == (int)DebugOptions::RENDER_PHYSICS_WORLD)
                         App->GetPhysicsModule()->SetDebugOption(currentBitValue);
                 }
             }
@@ -629,7 +629,6 @@ void Scene::UpdateGameObjects()
             gameObject->UpdateComponents();
             gameObject->SetWillUpdate(false);
         }
-
     }
     gameObjectsToUpdate.clear();
 }
@@ -640,9 +639,9 @@ void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
 
     if (pairResult.second)
     {
-        GameObject* selectedGameObject = GetGameObjectByUID(gameObject);
+        GameObject* selectedGameObject       = GetGameObjectByUID(gameObject);
         GameObject* selectedGameObjectParent = GetGameObjectByUID(gameObjectParent);
-        
+
         selectedGameObjectParent->RemoveGameObject(gameObject);
 
         multiSelectParent->AddGameObject(gameObject);
@@ -653,13 +652,30 @@ void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
 
         selectedGameObjectUID = multiSelectParent->GetUID();
     }
+    else if (pairResult.first != selectedGameObjects.end())
+    {
+        multiSelectParent->RemoveGameObject(gameObject);
+
+        GameObject* selectedGameObject       = GetGameObjectByUID(gameObject);
+        GameObject* selectedGameObjectParent = GetGameObjectByUID(selectedGameObjects[gameObject]);
+
+        selectedGameObject->SetParent(selectedGameObjectParent->GetUID());
+        selectedGameObjectParent->AddGameObject(gameObject);
+
+        if (selectedGameObjectParent->GetUID() != gameObjectRootUID)
+        {
+            selectedGameObject->UpdateLocalTransform(selectedGameObjectParent->GetGlobalTransform());
+            selectedGameObject->UpdateTransformForGOBranch();
+        }
+        selectedGameObjects.erase(pairResult.first);
+    }
 }
 
 void Scene::ClearObjectSelection()
 {
     for (auto& pairGameObject : selectedGameObjects)
     {
-        GameObject* currentGameObject = GetGameObjectByUID(pairGameObject.first); 
+        GameObject* currentGameObject        = GetGameObjectByUID(pairGameObject.first);
         GameObject* selectedGameObjectParent = GetGameObjectByUID(pairGameObject.second);
 
         multiSelectParent->RemoveGameObject(pairGameObject.first);
@@ -687,6 +703,11 @@ const std::vector<Component*> Scene::GetAllComponents() const
         }
     }
     return collectedComponents;
+}
+
+UID Scene::GetMultiselectUID() const
+{
+    return multiSelectParent->GetUID();
 }
 
 void Scene::SetMultiselectPosition(const float3& newPosition)

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -42,7 +42,7 @@ class Scene
     void OverridePrefabs(UID prefabUID);
 
     update_status Update(float deltaTime);
-    update_status Render(float deltaTime) const;
+    update_status Render(float deltaTime);
     update_status RenderEditor(float deltaTime);
 
     void RenderEditorControl(bool& editorControlMenu);

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -52,6 +52,7 @@ class Scene
 
     bool IsStaticModified() const { return staticModified; };
     bool IsDynamicModified() const { return dynamicModified; };
+    bool IsMultiselecting() const { return selectedGameObjects.size() > 0; };
 
     void UpdateStaticSpatialStructure();
     void UpdateDynamicSpatialStructure();
@@ -97,6 +98,7 @@ class Scene
 
     void SetStaticModified() { staticModified = true; }
     void SetDynamicModified() { dynamicModified = true; }
+    void SetMultiselectPosition(const float3& newPosition);
 
   private:
     void CreateStaticSpatialDataStruct();

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -92,6 +92,7 @@ class Scene
     const std::tuple<float, float>& GetMousePosition() const { return mousePosition; };
     Octree* GetOctree() const { return sceneOctree; }
     Quadtree* GetDynamicTree() const { return dynamicTree; }
+    UID GetMultiselectUID() const;
 
     void SetSelectedGameObject(UID newSelectedGameObject) { selectedGameObjectUID = newSelectedGameObject; };
 

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -62,10 +62,7 @@ class Scene
     void AddGameObjectToUpdate(GameObject* gameObject);
     void UpdateGameObjects();
 
-    void AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
-    {
-        selectedGameObjects.insert({gameObject, gameObjectParent});
-    }
+    void AddGameObjectToSelection(UID gameObject, UID gameObjectParent);
     void ClearObjectSelection();
 
     const std::string& GetSceneName() const { return sceneName; }

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -4,10 +4,11 @@
 #include "LightsConfig.h"
 
 #include "Math/float4x4.h"
+#include <functional>
 #include <map>
-#include <vector>
 #include <tuple>
 #include <unordered_map>
+#include <vector>
 
 class GameObject;
 class Component;
@@ -61,6 +62,12 @@ class Scene
     void AddGameObjectToUpdate(GameObject* gameObject);
     void UpdateGameObjects();
 
+    void AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
+    {
+        selectedGameObjects.insert({gameObject, gameObjectParent});
+    }
+    void ClearObjectSelection();
+
     const std::string& GetSceneName() const { return sceneName; }
     UID GetSceneUID() const { return sceneUID; }
     UID GetGameObjectRootUID() const { return gameObjectRootUID; }
@@ -93,7 +100,7 @@ class Scene
 
     void SetStaticModified() { staticModified = true; }
     void SetDynamicModified() { dynamicModified = true; }
-    
+
   private:
     void CreateStaticSpatialDataStruct();
     void CreateDynamicSpatialDataStruct();
@@ -125,4 +132,7 @@ class Scene
     bool dynamicModified                         = false;
 
     std::vector<GameObject*> gameObjectsToUpdate;
+
+    GameObject* multiSelectParent = nullptr;
+    std::map<UID, UID> selectedGameObjects;
 };

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -53,6 +53,7 @@ class Scene
     bool IsStaticModified() const { return staticModified; };
     bool IsDynamicModified() const { return dynamicModified; };
     bool IsMultiselecting() const { return selectedGameObjects.size() > 0; };
+    bool IsSceneFocused() const { return isFocused; };
 
     void UpdateStaticSpatialStructure();
     void UpdateDynamicSpatialStructure();
@@ -115,6 +116,7 @@ class Scene
     bool doInputs      = false;
     bool doMouseInputs = false;
     bool sceneVisible  = false;
+    bool isFocused     = false;
 
     std::unordered_map<UID, GameObject*> gameObjectsContainer;
 

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -79,13 +79,16 @@ namespace RaycastController
             UID rootGameObject           = sceneModule->GetScene()->GetGameObjectRootUID();
             GameObject* parentGameobject = sceneModule->GetScene()->GetGameObjectByUID(selectedGameObject->GetParent());
 
-            while (parentGameobject->GetUID() != rootGameObject && !parentGameobject->IsTopParent())
+            if (parentGameobject)
             {
-                selectedGameObject = parentGameobject;
-                parentGameobject   = sceneModule->GetScene()->GetGameObjectByUID(selectedGameObject->GetParent());
-            }
+                while (parentGameobject && parentGameobject->GetUID() != rootGameObject && !parentGameobject->IsTopParent())
+                {
+                    selectedGameObject = parentGameobject;
+                    parentGameobject   = sceneModule->GetScene()->GetGameObjectByUID(selectedGameObject->GetParent());
+                }
 
-            if (parentGameobject->IsTopParent()) selectedGameObject = parentGameobject;
+                if (parentGameobject && parentGameobject->IsTopParent()) selectedGameObject = parentGameobject;
+            }
         }
 
         return selectedGameObject;

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -81,7 +81,9 @@ namespace RaycastController
 
             if (parentGameobject)
             {
-                while (parentGameobject && parentGameobject->GetUID() != rootGameObject && !parentGameobject->IsTopParent())
+                while (parentGameobject && parentGameobject->GetUID() != rootGameObject &&
+                       !parentGameobject->IsTopParent() &&
+                       parentGameobject->GetUID() != sceneModule->GetScene()->GetMultiselectUID())
                 {
                     selectedGameObject = parentGameobject;
                     parentGameobject   = sceneModule->GetScene()->GetGameObjectByUID(selectedGameObject->GetParent());


### PR DESCRIPTION
Adds the multi selection feature.

To test:
Add different game objects / models to the scene and by holding Left Shift and clicking objects AABB should render arround the selected ones and by moving the gizmo all objects should move together.

I know that those objects dissapear temporarily from the tree node view (code limitations).

Clicking outside the scene window or just left clicking should restore the tree view and all multiselected objects should stop rendering the AABB.

![multiSelect](https://github.com/user-attachments/assets/062e9a8c-5e58-473b-a76e-c9655e699e5c)
