### PR TITLE
Player movement controller update 2 THO-212

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.h
@@ -2,6 +2,10 @@
 
 #include "Component.h"
 
+class dtNavMeshQuery;
+
+using dtPolyRef = unsigned int;
+
 class CharacterControllerComponent : public Component
 {
 
@@ -17,7 +21,8 @@ class CharacterControllerComponent : public Component
     void Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator) const override;
     void Clone(const Component* other) override;
 
-    void Move(const float3& direction, float deltaTime) const;
+    void AdjustHeightToNavMesh(float3& currentPos);
+    void Move(const float3& direction, float deltaTime);
     void Rotate(float rotationDirection, float deltaTime);
     void HandleInput(float deltaTime);
 
@@ -35,4 +40,11 @@ class CharacterControllerComponent : public Component
     float maxAngularSpeed;
 
     bool isRadians;
+
+    dtNavMeshQuery* navMeshQuery = nullptr;
+    dtPolyRef currentPolyRef     = 0;
+
+    float gravity                = -9.81f;
+    float verticalSpeed          = 0.0f;
+    float maxFallSpeed           = -20.0f;
 };


### PR DESCRIPTION
Now the player is able to walk though the navmesh, similar that the AI Agent component does. It clamps the position outside the borders of the navMesh in order to not fall and also in holes that could possibly have the navMesh inside.

To make things easier, a manual gravity has been applied in characterControllerComponent to control the height between the player and the navMesh. If we need to check this let me know and we can reformulate that part, but at the moment it works perfectly fine.

To test this:

Create a Scene with some gameObjects that work as a floor and some obstacles
Create some objects that can work as a height to be able to climb them.
Once the scene is created, create the navMesh and adjust the parameters according to the test you want to try.
After NavMesh is created, place a gameObject that will act as the player with a mesh and a playerController component.
You can place the player a little bit higher just in case it does not overlap the player. (the gravity will work and place in the correct spot in the navMesh)
play with it with WASD keys.
If you find any error, please let me know to solve it as soon as possible.

Bug known that has been found: if you try to to on playMode with a gameObject that has a characterControllerComponent and the scene does not have a NavMesh, the engine crashes. This is known and I'm trying to sort it out to avoid crashing if a navMesh is not there.

(Original pull request closed due to conflicts with merge. Original pull request #104 )