### PR TITLE
Animation Clips-THO-376

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -95,7 +95,7 @@ namespace AnimationImporter
         }
 
         // Handle UID
-        const std::string fileName = FileSystem::GetFileNameWithoutExtension(sourceFilePath);
+        const std::string fileName = FileSystem::GetFileNameWithoutExtension(sourceFilePath) + "_" + animation.name;
         UID finalAnimUID;
         if (sourceUID == INVALID_UID)
         {
@@ -128,12 +128,12 @@ namespace AnimationImporter
             return 0;
         }
 
-      
+        
         App->GetLibraryModule()->AddAnimation(finalAnimUID, fileName);
         App->GetLibraryModule()->AddName(fileName, finalAnimUID);
         App->GetLibraryModule()->AddResource(saveFilePath, finalAnimUID);
 
-        GLOG("%s saved as binary", FileSystem::GetFileNameWithoutExtension(sourceFilePath).c_str());
+        GLOG("%s saved as binary",  fileName.c_str());
 
         return finalAnimUID;
     }

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -11,8 +11,8 @@
 #include "ResourcesModule.h"
 #include "SceneModule.h"
 
-#include "imgui.h"
 #include "Math/Quat.h"
+#include "imgui.h"
 
 AnimationComponent::AnimationComponent(const UID uid, GameObject* parent)
     : Component(uid, parent, "Animation", COMPONENT_ANIMATION)
@@ -78,14 +78,20 @@ void AnimationComponent::OnResume()
 
 void AnimationComponent::OnInspector()
 {
-
+    std::string originAnimation = "";
     if (resource != 0)
     {
         currentAnimResource = dynamic_cast<ResourceAnimation*>(App->GetResourcesModule()->RequestResource(resource));
-
+        const std::string animationName = App->GetLibraryModule()->GetResourceName(resource);
+        
+        size_t underscorePos            = animationName.find('_');
+        if (underscorePos != std::string::npos)
+        {
+            originAnimation = animationName.substr(0, underscorePos);
+        }
         if (currentAnimResource != nullptr)
         {
-            ImGui::Text("Animation: %s", currentAnimResource->GetName().c_str());
+            ImGui::Text("Animation: %s", animationName.c_str());
             ImGui::Text("Duration: %.2f seconds", currentAnimResource->GetDuration());
 
             if (animController != nullptr && ImGui::TreeNode("Channels"))
@@ -247,8 +253,39 @@ void AnimationComponent::OnInspector()
 
     if (ImGui::CollapsingHeader("Animation Library"))
     {
+        std::string selectedZombunnyAnim = "";
+        UID selectedZombunnyUID          = 0;
 
         ImGui::Text("Available Animations:");
+        const std::unordered_map<std::string, UID>& animationMap = App->GetLibraryModule()->GetAnimMap();
+
+        std::unordered_map<std::string, std::vector<std::string>> groupedAnimations;
+
+        for (const auto& pair : animationMap)
+        {
+            const std::string& animationName = pair.first;
+
+            if (animationName.rfind(originAnimation, 0) == 0)
+            {
+                bool isSelected = (selectedZombunnyAnim == animationName);
+
+                if (ImGui::Selectable(animationName.c_str(), isSelected))
+                {
+                    selectedZombunnyAnim = animationName;
+                    resource             = pair.second;
+
+                    if (currentAnimComp->playing)
+                    {
+                        playing     = false;
+                        currentTime = 0.0f;
+                        currentAnimComp->OnStop();
+                    }
+
+                    GLOG("Selected animation: %s (UID: %llu)", animationName.c_str(), resource);
+                }
+            }
+        }
+
     }
 
     if (playing && currentAnimComp && currentAnimComp->GetAnimationController())


### PR DESCRIPTION
Now the diferent clips in an animation are saved with a diferent name and sowed on the inspector of the component. 

You can select the diferent animations and play the one you selected.

I attach here the zombunny with 2 animations, that is the same animation copied 2 times. For seeing visually the diference between the original and the copy you will see that Take 002 has bones erased, so in this animation you will see for example that doesn't have legs. You can check also on the inspector the information of each one.
This bug is important for finishing the state machine task so please test it as soon as you can.

<img width="671" alt="image" src="https://github.com/user-attachments/assets/3979dda9-250c-4b20-9782-1f4a21430848" />


[ZomBunnySpecular (2) (1).zip](https://github.com/user-attachments/files/19726612/ZomBunnySpecular.2.1.zip)
