### PR TITLE
Bug/lg mesh import from meta THO-388

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
@@ -17,8 +17,8 @@ namespace MeshImporter
 {
 
     UID ImportMesh(
-        const tinygltf::Model& model, const uint32_t meshIndex, const uint32_t primitiveIndex,
-        const std::string& name, const float4x4& meshTransform, const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID,
+        const tinygltf::Model& model, const uint32_t meshIndex, const uint32_t primitiveIndex, const std::string& name,
+        const float4x4& meshTransform, const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID,
         UID defaultMatUID
     )
     {
@@ -29,14 +29,14 @@ namespace MeshImporter
         std::vector<unsigned short> indexBufferShort;
         std::vector<unsigned int> indexBufferInt;
         size_t posStride = 0, tanStride = 0, texStride = 0, normStride = 0, jointStride = 0, weightsStride = 0;
-        float3 minPos         = {0.0f, 0.0f, 0.0f};
-        float3 maxPos         = {0.0f, 0.0f, 0.0f};
-        bool generateTangents = false;
+        float3 minPos                        = {0.0f, 0.0f, 0.0f};
+        float3 maxPos                        = {0.0f, 0.0f, 0.0f};
+        bool generateTangents                = false;
 
         const tinygltf::Primitive& primitive = model.meshes[meshIndex].primitives[primitiveIndex];
 
         // First get the indices, the type is needed for the joints later
-        const auto& itIndices = primitive.indices;
+        const auto& itIndices                = primitive.indices;
         if (itIndices != -1)
         {
             const tinygltf::Accessor& indexAcc      = model.accessors[itIndices];
@@ -317,9 +317,11 @@ namespace MeshImporter
         {
             UID meshUID           = GenerateUID();
             finalMeshUID          = App->GetLibraryModule()->AssignFiletypeUID(meshUID, FileType::Mesh);
-            
-            std::string assetPath         = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
-            MetaMesh meta(finalMeshUID, assetPath, generateTangents, meshTransform, defaultMatUID, meshIndex, primitiveIndex);
+
+            std::string assetPath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
+            MetaMesh meta(
+                finalMeshUID, assetPath, generateTangents, meshTransform, defaultMatUID, meshIndex, primitiveIndex
+            );
             meta.Save(name, assetPath);
         }
         else finalMeshUID = sourceUID;

--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.h
@@ -25,8 +25,9 @@ enum DataType
 namespace MeshImporter
 {
     UID ImportMesh(
-        const tinygltf::Model& model, uint32_t meshIndex, uint32_t primitiveIndex,
-        const std::string& name, const float4x4& meshTransform, const char* filePath, const std::string& targetFilePath, UID sourceUID = INVALID_UID, UID defaultMatUID = INVALID_UID
+        const tinygltf::Model& model, uint32_t meshIndex, uint32_t primitiveIndex, const std::string& name,
+        const float4x4& meshTransform, const char* filePath, const std::string& targetFilePath,
+        UID sourceUID = INVALID_UID, UID defaultMatUID = INVALID_UID
     );
     const float4x4 GetMeshDefaultTransform(const tinygltf::Model& model, const std::string& name);
     const float4x4 GetNodeTransform(const tinygltf::Node& node);

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -79,7 +79,8 @@ namespace SceneImporter
                     }
 
                     const UID meshUID = MeshImporter::ImportMesh(
-                        model, srcNode.mesh, primitiveCounter, name, defaultTransform, filePath, targetFilePath, INVALID_UID, matUID
+                        model, srcNode.mesh, primitiveCounter, name, defaultTransform, filePath, targetFilePath,
+                        INVALID_UID, matUID
                     );
                     primitiveCounter++;
 
@@ -143,12 +144,13 @@ namespace SceneImporter
     }
 
     void ImportMeshFromMetadata(
-        const std::string& filePath, const std::string& targetFilePath, const std::string& name, const rapidjson::Value& importOptions, UID sourceUID
+        const std::string& filePath, const std::string& targetFilePath, const std::string& name,
+        const rapidjson::Value& importOptions, UID sourceUID
     )
     {
-        tinygltf::Model model = LoadModelGLTF(filePath.c_str(), targetFilePath);
+        tinygltf::Model model             = LoadModelGLTF(filePath.c_str(), targetFilePath);
 
-        const uint32_t gltfMeshIndex = importOptions["gltfMeshIndex"].GetInt();
+        const uint32_t gltfMeshIndex      = importOptions["gltfMeshIndex"].GetInt();
         const uint32_t gltfPrimitiveIndex = importOptions["gltfPrimitiveIndex"].GetInt();
 
         MeshImporter::ImportMesh(

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.h
@@ -15,7 +15,8 @@ namespace SceneImporter
     void ImportGLTF(const char* filePath, const std::string& targetFilePath);
     tinygltf::Model LoadModelGLTF(const char* filePath, const std::string& targetFilePath);
     void ImportMeshFromMetadata(
-        const std::string& filePath, const std::string& targetFilePath, const std::string& name, const rapidjson::Value& importOptions, UID sourceUID
+        const std::string& filePath, const std::string& targetFilePath, const std::string& name,
+        const rapidjson::Value& importOptions, UID sourceUID
     );
     void ImportMaterialFromMetadata(
         const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID

--- a/SobrassadaEngine/FileSystem/Meta/MetaMesh.cpp
+++ b/SobrassadaEngine/FileSystem/Meta/MetaMesh.cpp
@@ -1,6 +1,9 @@
 #include "MetaMesh.h"
 
-MetaMesh::MetaMesh(UID uid, const std::string& assetPath, bool generateTangents, const float4x4& transform, UID defaultMaterialUID, uint32_t gltfMeshIndex, uint32_t gltfPrimitiveIndex)
+MetaMesh::MetaMesh(
+    UID uid, const std::string& assetPath, bool generateTangents, const float4x4& transform, UID defaultMaterialUID,
+    uint32_t gltfMeshIndex, uint32_t gltfPrimitiveIndex
+)
     : MetaFile(uid, assetPath), generateTangents(generateTangents), transform(transform),
       defaultMaterialUID(defaultMaterialUID), gltfMeshIndex(gltfMeshIndex), gltfPrimitiveIndex(gltfPrimitiveIndex)
 {
@@ -34,5 +37,4 @@ void MetaMesh::AddImportOptions(rapidjson::Document& doc, rapidjson::Document::A
     importOptions.AddMember("gltfPrimitiveIndex", gltfPrimitiveIndex, allocator);
 
     doc.AddMember("importOptions", importOptions, allocator);
-    
 }

--- a/SobrassadaEngine/FileSystem/Meta/MetaMesh.h
+++ b/SobrassadaEngine/FileSystem/Meta/MetaMesh.h
@@ -7,25 +7,19 @@
 class MetaMesh : public MetaFile
 {
   public:
-    MetaMesh(UID uid, const std::string& assetPath, bool generateTangents, const float4x4& transform, UID defaultMaterialUID, uint32_t gltfMeshIndex, uint32_t gltfPrimitiveIndex);
+    MetaMesh(
+        UID uid, const std::string& assetPath, bool generateTangents, const float4x4& transform, UID defaultMaterialUID,
+        uint32_t gltfMeshIndex, uint32_t gltfPrimitiveIndex
+    );
     void AddImportOptions(rapidjson::Document& doc, rapidjson::Document::AllocatorType& allocator) const override;
 
-    uint32_t GetGltfMeshIndex() const
-    {
-        return gltfMeshIndex;
-    }
+    uint32_t GetGltfMeshIndex() const { return gltfMeshIndex; }
 
-    uint32_t GetGltfPrimitiveIndex() const
-    {
-        return gltfPrimitiveIndex;
-    }
+    uint32_t GetGltfPrimitiveIndex() const { return gltfPrimitiveIndex; }
 
-    const float4x4& GetTransform() const
-    {
-        return transform;
-    }
+    const float4x4& GetTransform() const { return transform; }
 
-private:
+  private:
     uint32_t gltfMeshIndex;
     uint32_t gltfPrimitiveIndex;
     bool generateTangents;

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -4,17 +4,17 @@
 #include "Component.h"
 #include "ComponentUtils.h"
 #include "FileSystem.h"
+#include "FileSystem/StateMachineManager.h"
 #include "GameObject.h"
 #include "ProjectModule.h"
 #include "SceneImporter.h"
 #include "SceneModule.h"
 #include "TextureImporter.h"
-#include "FileSystem/StateMachineManager.h"
 
-#include "rapidjson/writer.h"
 #include "rapidjson/document.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
 #include <filesystem>
 #include <fstream>
 
@@ -143,8 +143,7 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
             std::string libraryPath;
 
             rapidjson::Value importOptions;
-            if (doc.HasMember("importOptions") && doc["importOptions"].IsObject())
-                importOptions = doc["importOptions"];
+            if (doc.HasMember("importOptions") && doc["importOptions"].IsObject()) importOptions = doc["importOptions"];
 
             switch (prefix)
             {
@@ -179,7 +178,7 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
             case 15:
                 AddAnimation(assetUID, assetName);
                 AddName(assetName, assetUID);
-                libraryPath = projectPath + ANIMATIONS_PATH+ std::to_string(assetUID) + ANIMATION_EXTENSION;
+                libraryPath = projectPath + ANIMATIONS_PATH + std::to_string(assetUID) + ANIMATION_EXTENSION;
                 if (FileSystem::Exists(libraryPath.c_str())) AddResource(libraryPath, assetUID);
                 else SceneImporter::CopyModel(assetPath, projectPath, assetName, assetUID);
                 break;
@@ -378,7 +377,6 @@ UID LibraryModule::GetModelUID(const std::string& modelPath) const
     return INVALID_UID;
 }
 
-
 UID LibraryModule::GetAnimUID(const std::string& animPath) const
 {
     auto it = animMap.find(animPath);
@@ -407,8 +405,8 @@ const std::string& LibraryModule::GetResourcePath(UID resourceID) const
     auto it = resourcePathsMap.find(resourceID);
     if (it != resourcePathsMap.end())
     {
-        //GLOG("requested uid: %llu", resourceID);
-        //GLOG("obtained path: %s", it->second.c_str());
+        // GLOG("requested uid: %llu", resourceID);
+        // GLOG("obtained path: %s", it->second.c_str());
         return it->second;
     }
     static const std::string emptyString = "";
@@ -420,8 +418,8 @@ const std::string& LibraryModule::GetResourceName(UID resourceID) const
     auto it = namesMap.find(resourceID);
     if (it != namesMap.end())
     {
-        //GLOG("requested uid: %llu", resourceID);
-        //GLOG("obtained name: %s", it->second.c_str());
+        // GLOG("requested uid: %llu", resourceID);
+        // GLOG("obtained name: %s", it->second.c_str());
         return it->second;
     }
     static const std::string emptyString = "";


### PR DESCRIPTION
With the recent changes regarding naming of assets, the import of meshes from meta files was broken. 
This pr solves that issue. It finds the primitives of a gltf now based on indices of gltf arrays instead of name comparisons.

For testing:
- import fresh gltfs into the engine (old meta files won´t work anymore)
- save scene with objects placed
- close engine, delete library folder, reopen it
- the meshes should be loaded correctly